### PR TITLE
[#2457] Fix unknown encoding cp65001 error on Windows.

### DIFF
--- a/src/python/Python-2.7.3/Lib/encodings/aliases.py
+++ b/src/python/Python-2.7.3/Lib/encodings/aliases.py
@@ -516,6 +516,7 @@ aliases = {
     'utf8'               : 'utf_8',
     'utf8_ucs2'          : 'utf_8',
     'utf8_ucs4'          : 'utf_8',
+    'cp65001'            : 'utf_8',
 
     # uu_codec codec
     'uu'                 : 'uu_codec',

--- a/src/python/Python-2.7.6/Lib/encodings/aliases.py
+++ b/src/python/Python-2.7.6/Lib/encodings/aliases.py
@@ -516,6 +516,7 @@ aliases = {
     'utf8'               : 'utf_8',
     'utf8_ucs2'          : 'utf_8',
     'utf8_ucs4'          : 'utf_8',
+    'cp65001'            : 'utf_8',
 
     # uu_codec codec
     'uu'                 : 'uu_codec',


### PR DESCRIPTION
## Problem

On windows machines after running the server (fixed in the meantime) and/or running the testsuite an error is printed on any subsequent Python command:

```
LookupError: unknown encoding: cp65001
```
## Changes

Added `cp65001` as an alias for `utf_8`.
## How to test

reviewers @adiroiban

Please check that the code changes make sense. Once you approve I will generate a new distribution and replace the existing one.

I've tested the changes on my local machine and they work as expected.
