### PR TITLE
[#2638] Use 2.7.8 for all platforms.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -18,7 +18,7 @@ SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel"
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
-PYTHON_BUILD_VERSION=2.7.9
+PYTHON_BUILD_VERSION=2.7.8
 PYSQLITE_VERSION=2.6.3
 SQLITE_VERSION=3.8.1
 
@@ -81,6 +81,8 @@ case $OS in
         fi
         ;;
     solaris*)
+        # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
+        # 2.7.9 do not support it. More at https://bugs.python.org/issue20981.
         if [ "$OS" = "solaris10" ]; then
             PYTHON_BUILD_VERSION=2.7.8
         fi

--- a/pavement.py
+++ b/pavement.py
@@ -25,6 +25,7 @@ from brink.pavement_commons import (
     pave,
     SETUP,
     test_remote,
+    test_review,
     )
 from paver.easy import task
 
@@ -36,6 +37,7 @@ github
 harness
 help
 test_remote
+test_review
 
 SETUP['product']['name'] = 'python'
 SETUP['folders']['source'] = u'src'


### PR DESCRIPTION
Problem?
-----------

Python 2.7.9's new SSL module is giving us headaches. 

Solution?
-----------

Temporarily downgrade to 2.7.8 for all platforms.

How to test?
----------------

Please review changes.
Test, test, test.

reviewer: @adiroiban 