### PR TITLE
[#2633] Include GMP for all platforms.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -86,7 +86,7 @@ case $OS in
         if [ "$OS" = "solaris10" ]; then
             PYTHON_BUILD_VERSION=2.7.8
         fi
-        # By default we compile with the Sun Studio compiler. If you want GCC
+        # By default, we compile with the Sun Studio compiler. If you want GCC
         # 3.x or 4.x, change this and export the appropriate PATH below.
         export CC=cc
         # CXX is not really needed, we set it to suppress some warnings and
@@ -105,6 +105,13 @@ case $OS in
             export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="-m64"
         fi
+        ;;
+    *)
+        # By default, we compile with GCC in Linux and OS X.
+        export CC=gcc
+        # CXX is not really needed, we set it to suppress some warnings.
+        # However, we'll set CPPFLAGS later...
+        export CXX=g++
         ;;
 esac
 

--- a/chevah_build
+++ b/chevah_build
@@ -184,12 +184,14 @@ command_build() {
     case $OS in
         aix*)
             build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
-            build 'gmp' "gmp-$GMP_VERSION" ${PYTHON_BUILD_FOLDER}
             ;;
         solaris*)
             build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
             ;;
     esac
+
+    # Build GMP on all platforms.
+    build 'gmp' "gmp-$GMP_VERSION" ${PYTHON_BUILD_FOLDER}
 
     build 'python' "Python-$PYTHON_BUILD_VERSION" ${PYTHON_BUILD_FOLDER}
 
@@ -249,17 +251,12 @@ command_build_python_extra_libraries() {
     execute cp $makefile $makefile_orig
     sed "s#^prefix=.*#prefix= $INSTALL_FOLDER#" $makefile_orig > $makefile
 
-    # We need GMP or MPIR for fast math in pycrypto.
-    case $OS in
-        aix*)
-            # There is no GMP/MPIR available from IBM. Since GMP seems to care
-            # more about AIX, we build that and make it available to pycrypto.
-            cp $INSTALL_FOLDER/tmp/gmp/gmp.h $INSTALL_FOLDER/include
-            cp $INSTALL_FOLDER/tmp/gmp/libgmp* $INSTALL_FOLDER/lib
-            export CPPFLAGS="${CPPFLAGS} -I$INSTALL_FOLDER/include/"
-            export LDFLAGS="${LDFLAGS} -L$INSTALL_FOLDER/lib/"
-        ;;
-    esac
+    # We need GMP or MPIR for fast math in pycrypto. We use GMP because
+    # its devs do a better job of supporting exotic platforms such as AIX.
+    cp $INSTALL_FOLDER/tmp/gmp/gmp.h $INSTALL_FOLDER/include
+    cp $INSTALL_FOLDER/tmp/gmp/libgmp* $INSTALL_FOLDER/lib
+    export CPPFLAGS="${CPPFLAGS} -I$INSTALL_FOLDER/include/"
+    export LDFLAGS="${LDFLAGS} -L$INSTALL_FOLDER/lib/"
 
     for library in $EXTRA_LIBRARIES ; do
         # Library is in the form pyopenssl/PyOpenssl-2.4.5

--- a/chevah_build
+++ b/chevah_build
@@ -86,8 +86,12 @@ case $OS in
         if [ "$OS" = "solaris10" ]; then
             PYTHON_BUILD_VERSION=2.7.8
         fi
-        # By default we compile with the Sun Studio compiler.
-        # If you want to use GCC 3.x or 4.x, please export the appropriate PATH.
+        # By default we compile with the Sun Studio compiler. If you want GCC
+        # 3.x or 4.x, change this and export the appropriate PATH below.
+        export CC=cc
+        # CXX is not really needed, we set it to suppress some warnings and
+        # to make sure g++ is never used. However, we'll set CPPFLAGS later...
+        export CXX=CC
         # This is the default-included GNU make and its counterpart: makeinfo.
         export MAKE=/usr/sfw/bin/gmake
         export MAKEINFO=/usr/sfw/bin/makeinfo

--- a/chevah_build
+++ b/chevah_build
@@ -12,9 +12,9 @@
 . ./functions.sh
 
 # List of OS packages required for building Python.
-UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev"
-RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel"
-SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel"
+UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4"
+RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4"
+SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel m4"
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0

--- a/chevah_build
+++ b/chevah_build
@@ -262,7 +262,7 @@ command_build_python_extra_libraries() {
     execute cp $makefile $makefile_orig
     sed "s#^prefix=.*#prefix= $INSTALL_FOLDER#" $makefile_orig > $makefile
 
-    # We need GMP or MPIR for fast math in pycrypto. We use GMP because
+    # We need GMP or MPIR for fast math in PyCrypto. We use GMP because
     # its devs do a better job of supporting exotic platforms such as AIX.
     cp $INSTALL_FOLDER/tmp/gmp/gmp.h $INSTALL_FOLDER/include
     cp $INSTALL_FOLDER/tmp/gmp/libgmp* $INSTALL_FOLDER/lib

--- a/paver.sh
+++ b/paver.sh
@@ -67,7 +67,7 @@ ARCH='x86'
 # For non-LSB distros we use the oldest supported Linux distro. No guarantees
 # made... For details, please see the Linux bits in detect_os() below.
 OS_LINUX_LSB='ubuntu1204'
-OS_LINUX_NONLSB='rhel4'
+OS_LINUX_NONLSB='ubuntu1004'
 
 
 clean_build() {

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -72,6 +72,13 @@ except:
     print '"ctypes.utils - find_library" missing.'
     exit_code = 1
 
+try:
+    from Crypto.PublicKey import _fastmath
+    _fastmath
+except:
+    print 'Crypto.PublicKey._fastmath missing. No GMP?'
+    exit_code = 1
+
 # Windows specific modules.
 if os.name == 'nt':
     try:

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -7,7 +7,13 @@
 
 chevahbs_configure() {
     # We want only static build so that we don't have to mess with LIBPATH.
-    execute ./configure --prefix="" --disable-shared --enable-static
+    CONF_OPTS="--disable-shared --enable-static"
+    if [ x${ARCH} == x"x64" -a  x${os} != x"solaris" ]; then
+        # Fix relocation error for amd64 in Linux. More at:
+        # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
+        CONF_OPTS="$CONF_OPTS --with-pic"
+    fi
+    execute ./configure --prefix="" $CONF_OPTS
 }
 
 

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -10,20 +10,14 @@ chevahbs_configure() {
     # We want only static build so that we don't have to mess with LIBPATH.
     CONF_OPTS="--disable-shared --enable-static"
     if [ x${ARCH} == x"x64" -o x${ARCH} == x"x86" ]; then
+        # Select a "fat binary" build on x86/x64, where optimized low level
+        # subroutines are chosen at runtime according to the CPU detected.
+        # This means more code, but gives good performance on all chips.
+        CONF_OPTS="$CONF_OPTS --enable-fat"
         if [ x${ARCH} == x"x64" ]; then
             # Fix lib relocation error for x64. More details at:
             # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
             CONF_OPTS="$CONF_OPTS --with-pic"
-        fi
-        if [ x${OS##osx} != x"$OS" ]; then
-            # See https://gmplib.org/manual/Build-Options.html and the list of
-            # relevant CPUs from ./src/gmp/gmp-6.0.0/mpn/x86_64/fat/fat.c.
-            export MPN_PATH="x86_64/core2 x86_64 generic"
-        else
-            # Select a "fat binary" build on x86/x64, where optimized low level
-            # subroutines are chosen at runtime according to the CPU detected.
-            # This means more code, but gives good performance on all chips.
-            CONF_OPTS="$CONF_OPTS --enable-fat"
         fi
     fi
     execute ./configure --prefix="" $CONF_OPTS

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -5,18 +5,25 @@
 # Import shared code.
 . ./functions.sh
 
+
 chevahbs_configure() {
     # We want only static build so that we don't have to mess with LIBPATH.
     CONF_OPTS="--disable-shared --enable-static"
     if [ x${ARCH} == x"x64" -o x${ARCH} == x"x86" ]; then
-        # Select a "fat binary" build on x86/x64, where optimized low level
-        # subroutines are chosen at runtime according to the CPU detected.
-        # This means more code, but gives good performance on all chips.
-        CONF_OPTS="$CONF_OPTS --enable-fat"
-        # Fix lib relocation error for x64. More details at:
-        # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
         if [ x${ARCH} == x"x64" ]; then
+            # Fix lib relocation error for x64. More details at:
+            # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
             CONF_OPTS="$CONF_OPTS --with-pic"
+        fi
+        if [ x${OS##osx} != x"$OS" ]; then
+            # See https://gmplib.org/manual/Build-Options.html and the list of
+            # relevant CPUs from ./src/gmp/gmp-6.0.0/mpn/x86_64/fat/fat.c.
+            export MPN_PATH="x86_64/core2 x86_64 generic"
+        else
+            # Select a "fat binary" build on x86/x64, where optimized low level
+            # subroutines are chosen at runtime according to the CPU detected.
+            # This means more code, but gives good performance on all chips.
+            CONF_OPTS="$CONF_OPTS --enable-fat"
         fi
     fi
     execute ./configure --prefix="" $CONF_OPTS

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -8,10 +8,16 @@
 chevahbs_configure() {
     # We want only static build so that we don't have to mess with LIBPATH.
     CONF_OPTS="--disable-shared --enable-static"
-    if [ x${ARCH} == x"x64" -a  x${os} != x"solaris" ]; then
-        # Fix relocation error for amd64 in Linux. More at:
+    if [ x${ARCH} == x"x64" -o x${ARCH} == x"x86" ]; then
+        # Select a “fat binary” build on x86/x64, where optimized low level
+        # subroutines are chosen at runtime according to the CPU detected.
+        # This means more code, but gives good performance on all x86 chips.
+        CONF_OPTS="$CONF_OPTS --enable-fat"
+        # Fix lib relocation error for x64 when using GCC. More details at:
         # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
-        CONF_OPTS="$CONF_OPTS --with-pic"
+        if [ x${ARCH} == x"x64" -a x${CC} == x"gcc" ]; then
+            CONF_OPTS="$CONF_OPTS --with-pic"
+        fi
     fi
     execute ./configure --prefix="" $CONF_OPTS
 }

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -2,8 +2,6 @@
 #
 # Chevah Build Script for GMP.
 #
-# For now it is supported only on AIX.
-#
 # Import shared code.
 . ./functions.sh
 
@@ -23,17 +21,15 @@ chevahbs_compile() {
 
 chevahbs_install() {
     install_folder=$1
-    if [ x${ARCH##ppc} != x"$ARCH" ]; then
-        # As with libffi, we copy the files manually to a temporary location
-        # and then we copy them from there just in time for the compilation of
-        # pycrypto. Which we instruct to use them through augmenting CPPFLAGS
-        # with the include's location and LDFLAGS with the location of the libs.
-        local temp_folder=$INSTALL_FOLDER/tmp/gmp/
-        execute mkdir -p $temp_folder
-        execute cp .libs/* $temp_folder
-        ranlib $temp_folder/libgmp.a
-        execute cp gmp.h $temp_folder
-    fi
+    # As with libffi, we copy the files manually to a temporary location
+    # and then we copy them from there just in time for the compilation of
+    # pycrypto. Which we instruct to use them through augmenting CPPFLAGS
+    # with the include's location and LDFLAGS with the location of the libs.
+    local temp_folder=$INSTALL_FOLDER/tmp/gmp/
+    execute mkdir -p $temp_folder
+    execute cp .libs/* $temp_folder
+    ranlib $temp_folder/libgmp.a
+    execute cp gmp.h $temp_folder
 }
 
 

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -34,9 +34,9 @@ chevahbs_compile() {
 
 chevahbs_install() {
     install_folder=$1
-    # As with libffi, we copy the files manually to a temporary location
-    # and then we copy them from there just in time for the compilation of
-    # pycrypto. Which we instruct to use them through augmenting CPPFLAGS
+    # As with libffi, we copy the files manually to a temporary location and
+    # then we get them from there before compiling PyCrypto. We'll also have
+    # to instruct the compiler to link against our GMP by augmenting CPPFLAGS
     # with the include's location and LDFLAGS with the location of the libs.
     local temp_folder=$INSTALL_FOLDER/tmp/gmp/
     execute mkdir -p $temp_folder

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -9,13 +9,13 @@ chevahbs_configure() {
     # We want only static build so that we don't have to mess with LIBPATH.
     CONF_OPTS="--disable-shared --enable-static"
     if [ x${ARCH} == x"x64" -o x${ARCH} == x"x86" ]; then
-        # Select a “fat binary” build on x86/x64, where optimized low level
+        # Select a "fat binary" build on x86/x64, where optimized low level
         # subroutines are chosen at runtime according to the CPU detected.
-        # This means more code, but gives good performance on all x86 chips.
+        # This means more code, but gives good performance on all chips.
         CONF_OPTS="$CONF_OPTS --enable-fat"
-        # Fix lib relocation error for x64 when using GCC. More details at:
+        # Fix lib relocation error for x64. More details at:
         # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
-        if [ x${ARCH} == x"x64" -a x${CC} == x"gcc" ]; then
+        if [ x${ARCH} == x"x64" ]; then
             CONF_OPTS="$CONF_OPTS --with-pic"
         fi
     fi

--- a/src/gmp/gmp-6.0.0/mpn/x86_64/k8/redc_1.asm
+++ b/src/gmp/gmp-6.0.0/mpn/x86_64/k8/redc_1.asm
@@ -114,7 +114,7 @@ ifdef(`PIC',`
 
 	JUMPTABSECT
 	ALIGN(8)
-L(tab):	JMPENT(	L(0m4), L(tab))
+L(tab):	JMPENT(	L(0), L(tab))
 	JMPENT(	L(1), L(tab))
 	JMPENT(	L(2), L(tab))
 	JMPENT(	L(3), L(tab))
@@ -397,6 +397,7 @@ L(le1):	add	%r10, (up)
 
 
 	ALIGN(16)
+L(0):
 L(0m4):
 L(lo0):	mov	(mp,nneg,8), %rax
 	mov	nneg, i


### PR DESCRIPTION
Problem?
-------------
When GMP and MPIR libraries are missing, `PyCrypto` didn't build `Crypto.PublicKey._fastmath`.

Solution?
------------
Include latest GMP, as we do for AIX.

How to test?
----------------
Please review changes.
New test for GMP included.

reviewer: @adiroiban 