### PR TITLE
[#2629] Compilator choice in AIX and Solaris.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -40,15 +40,25 @@ fi
 PYTHON_VERSION=`cut -d' ' -f 2 DEFAULT_VALUES`
 OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
+CC=`cut -d' ' -f 5 DEFAULT_VALUES`
+CXX=`cut -d' ' -f 6 DEFAULT_VALUES`
 TIMESTAMP=`date +'%Y%m%d'`
 rm DEFAULT_VALUES
 
 # In Solaris and AIX we use $ARCH to choose if we build a 32bit or 64bit
 # package. This way we are able to force a 32bit build on a 64bit machine,
-# for example by exporting here ARCH as "x86" instead of "x64" or "ppc"
-# instead of "ppc64".
-# We also use $ARCH when building the external libs in AIX: libffi and GMP.
+# for example by exporting ARCH in paver.sh as "x86" instead of "x64" or
+# "ppc" instead of "ppc64".
+# We also use $ARCH when building the statically compiled libs: libffi and GMP.
 export ARCH
+# Explicitly choose the C compiler in order to make it possible to switch
+# between native compilers and GCC on platforms such as AIX and Solaris.
+# For that, paver.sh has the relevant lines to edit.
+export CC
+# CXX is not really needed, we export it to make sure g++ won't get picked up
+# when not using gcc and thus silence the associated configure warning. However,
+# we'll need to set CPPFLAGS later for linking to statically-compiled libs.
+export CXX
 
 LOCAL_PYTHON_BINARY_DIST="$PYTHON_VERSION-$OS-$ARCH"
 INSTALL_FOLDER=$PWD/${BUILD_FOLDER}/$LOCAL_PYTHON_BINARY_DIST
@@ -61,43 +71,42 @@ case $OS in
     aix*)
         export MAKE=gmake
         export PATH=/usr/vac/bin:$PATH
-        export CC=gcc
-        # CXX is not really needed, we set it to suppress some warnings and
-        # to make sure g++ is never used. However, we'll set CPPFLAGS later...
-        export CXX=g++
-        # IBM's OpenSSL libs are mixed 32/64bit binaries in AIX 7.1, so we need
-        # to be specific about what kind of build we want, because GMP by
-        # default compiles 64bit libraries.
+        export CFLAGS="-O2"
+        # IBM's OpenSSL libs are mixed 32/64bit binaries in AIX, so we need to
+        # be specific about what kind of build we want, because otherwise we
+        # might get 64bit libraries (eg. when building GMP).
         if [ "${ARCH%64}" = "$ARCH" ]; then
-            export CFLAGS="-O2"
             export OBJECT_MODE="32"
             export ABI="32"
             export AR="ar -X32"
+            if [ "${CC}" != "gcc" ]; then
+                export CFLAGS="$CFLAGS -qmaxmem=-1 -q32"
+            fi
         else
-            export CFLAGS="-O2 -qmaxmem=-1 -q64"
             export OBJECT_MODE="64"
             export ABI="mode64"
             export AR="ar -X64"
+            if [ "${CC}" != "gcc" ]; then
+                export CFLAGS="$CFLAGS -qmaxmem=-1 -q64"
+            fi
         fi
-        ;;
+    ;;
     solaris*)
         # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
         # 2.7.9 do not support it. More at https://bugs.python.org/issue20981.
         if [ "$OS" = "solaris10" ]; then
             PYTHON_BUILD_VERSION=2.7.8
         fi
-        # By default, we compile with the Sun Studio compiler. If you want GCC
-        # 3.x or 4.x, change this and export the appropriate PATH below.
-        export CC=cc
-        # CXX is not really needed, we set it to suppress some warnings and
-        # to make sure g++ is never used. However, we'll set CPPFLAGS later...
-        export CXX=CC
         # This is the default-included GNU make and its counterpart: makeinfo.
         export MAKE=/usr/sfw/bin/gmake
         export MAKEINFO=/usr/sfw/bin/makeinfo
         # We favour the BSD-flavoured "install" over the default one.
         # "ar", "nm" and "ld" are included by default in the same path.
         export PATH=/usr/ccs/bin/:$PATH
+        # GCC is not in the usual PATH, we add the path to it if we want it.
+        if [ "${CC}" = "gcc" ]; then
+            export PATH="$PATH:/usr/sfw/bin/"
+        fi
         # And this is where the GNU libs are in Solaris 10, including OpenSSL.
         if [ "${ARCH%64}" = "$ARCH" ]; then
             export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
@@ -105,14 +114,7 @@ case $OS in
             export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="-m64"
         fi
-        ;;
-    *)
-        # By default, we compile with GCC in Linux and OS X.
-        export CC=gcc
-        # CXX is not really needed, we set it to suppress some warnings.
-        # However, we'll set CPPFLAGS later...
-        export CXX=g++
-        ;;
+    ;;
 esac
 
 

--- a/chevah_build
+++ b/chevah_build
@@ -61,15 +61,15 @@ case $OS in
     aix*)
         export MAKE=gmake
         export PATH=/usr/vac/bin:$PATH
-        export CC=xlc_r
+        export CC=gcc
         # CXX is not really needed, we set it to suppress some warnings and
         # to make sure g++ is never used. However, we'll set CPPFLAGS later...
-        export CXX=xlC_r
+        export CXX=g++
         # IBM's OpenSSL libs are mixed 32/64bit binaries in AIX 7.1, so we need
         # to be specific about what kind of build we want, because GMP by
         # default compiles 64bit libraries.
         if [ "${ARCH%64}" = "$ARCH" ]; then
-            export CFLAGS="-O2 -qmaxmem=-1 -q32"
+            export CFLAGS="-O2"
             export OBJECT_MODE="32"
             export ABI="32"
             export AR="ar -X32"

--- a/paver.sh
+++ b/paver.sh
@@ -61,6 +61,8 @@ LOCAL_PYTHON_BINARY_DIST=""
 # Put default values and create them as global variables.
 OS='not-detected-yet'
 ARCH='x86'
+CC='gcc'
+CXX='g++'
 
 # When run on Linux distros other then those supported by us (Red Hat, SUSE,
 # Ubuntu), we match the LSB distros to the oldest Ubuntu LTS supported by us.
@@ -164,7 +166,7 @@ update_path_variables() {
 
 
 write_default_values() {
-    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} > DEFAULT_VALUES
+    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} ${CC} ${CXX} > DEFAULT_VALUES
 }
 
 
@@ -352,6 +354,10 @@ detect_os() {
 
     elif [ "${OS}" = "sunos" ] ; then
 
+        # By default, we use Sun's Studio compiler. Comment these two for GCC.
+        CC="cc"
+        CXX="CC"
+
         OS="solaris"
         ARCH=`isainfo -n`
         VERSION=`uname -r`
@@ -369,6 +375,11 @@ detect_os() {
         fi
 
     elif [ "${OS}" = "aix" ] ; then
+
+        # By default, we use IBM's XL C compiler. Comment these two for GCC.
+        # Beware that GCC 4.2 from IBM's RPMs will fail with GMP and Python!
+        CC="xlc_r"
+        CXX="xlC_r"
 
         release=`oslevel`
         case $release in

--- a/paver.sh
+++ b/paver.sh
@@ -362,14 +362,6 @@ detect_os() {
         ARCH=`isainfo -n`
         VERSION=`uname -r`
 
-        if [ "$ARCH" = "i386" ] ; then
-            ARCH='x86'
-        elif [ "$ARCH" = "amd64" ]; then
-            ARCH='x64'
-        elif [ "$ARCH" = "sparcv9" ] ; then
-            ARCH='sparc64'
-        fi
-
         if [ "$VERSION" = "5.10" ] ; then
             OS="solaris10"
         fi
@@ -381,19 +373,14 @@ detect_os() {
         CC="xlc_r"
         CXX="xlC_r"
 
+        ARCH="ppc`getconf HARDWARE_BITMODE`"
         release=`oslevel`
         case $release in
-            5.1.*)
-                OS='aix51'
-                ARCH='ppc'
-            ;;
             5.3.*)
                 OS='aix53'
-                ARCH='ppc'
             ;;
             7.1.*)
                 OS='aix71'
-                ARCH='ppc'
             ;;
         esac
 
@@ -473,13 +460,9 @@ detect_os() {
                 ;;
         esac
 
-        osx_arch=`uname -m`
-        if [ "$osx_arch" = "Power Macintosh" ] ; then
-            ARCH='ppc'
-        elif [ "$osx_arch" = "x86_64" ] ; then
-            ARCH='x64'
-        else
-            echo 'Unsuported OS X architecture:' $osx_arch
+        ARCH=`uname -m`
+        if [ "$ARCH" != "x86_64" ] ; then
+            echo 'Unsuported OS X architecture:' $ARCH
             exit 1
         fi
     else
@@ -488,16 +471,16 @@ detect_os() {
     fi
 
     # Fix arch names.
-    if [ "$ARCH" = "i686" ] ; then
+    if [ "$ARCH" = "i686" -o "$ARCH" = "i386" ]; then
         ARCH='x86'
-
-    fi
-    if [ "$ARCH" = "i386" ] ; then
-        ARCH='x86'
-    fi
-
-    if [ "$ARCH" = "x86_64" ] ; then
+    elif [ "$ARCH" = "x86_64" -o "$ARCH" = "amd64" ]; then
         ARCH='x64'
+    elif [ "$ARCH" = "sparcv9" ]; then
+        ARCH='sparc64'
+    elif [ "$ARCH" = "ppc64" ]; then
+        # Python has not been fully tested on AIX when compiled as a 64 bit
+        # application and has math rounding error problems (at least with XL C).
+        ARCH='ppc'
     fi
 }
 

--- a/python-modules/pycrypto-2.6.1/setup.py
+++ b/python-modules/pycrypto-2.6.1/setup.py
@@ -139,8 +139,6 @@ class PCTBuildExt (build_ext):
                 # Speed up execution by tweaking compiler options.  This
                 # especially helps the DES modules.
                 if sys.platform.startswith('aix'):
-                    self.__add_compiler_option("-O2")
-                    self.__add_compiler_option("-qmaxmem=70000")
                     self.__add_compiler_option("-D_LARGE_FILES")
                     self.__add_compiler_option("-D_LARGE_FILE_API")
                 else:

--- a/src/gmp/gmp-6.0.0/tests/mpz/reuse.c
+++ b/src/gmp/gmp-6.0.0/tests/mpz/reuse.c
@@ -26,7 +26,6 @@ the GNU MP Library test suite.  If not, see https://www.gnu.org/licenses/.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "gmp.h"
 #include "gmp-impl.h"

--- a/src/gmp/gmp-6.0.0/tests/mpz/reuse.c
+++ b/src/gmp/gmp-6.0.0/tests/mpz/reuse.c
@@ -26,6 +26,7 @@ the GNU MP Library test suite.  If not, see https://www.gnu.org/licenses/.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "gmp.h"
 #include "gmp-impl.h"

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -51,7 +51,6 @@ chevahbs_configure() {
             touch Include/Python-ast.h Python/Python-ast.c
             # MAXMEM option with a value greater than 8192.
             CONFIG_ARGS="${CONFIG_ARGS} \
-                --without-gcc \
                 --with-system-ffi \
                 "
             ;;


### PR DESCRIPTION
Problem?
------------
Our Python package is considerably slower in AIX compared to other OS'es. Reading up on problem performances in AIX for other free software products suggests compiling with GCC might considerably improve the situation.

Solution?
-------------
Make it possible to compile `python-package` with GCC in AIX and Solaris so that we can test this hypothesis.

**Drive-by fix**:
  * consolidated `ARCH` renaming in `paver.sh`.

How to test?
-----------------
Re-compile `python-package` with GCC in AIX/Solaris by commenting the lines exporting `CC` and `CXX`. 
Re-run server tests with the new package in `upload/testing`.

**Notes**: 
  * on AIX this requires a newer GCC than the one available from IBM 
  * only the AIX 5.3 vWPAR was tested with GCC, third-party RPMs were used
  * only the included GCC3 was used to test Solaris 10 and only for a 64bit build
  * only the package compiled with GCC on AIX 5.3 was tested with server tests and it turned out to be about the same speed.

reviewer: @adiroiban  