### PR TITLE
[#2647] Generic Linux x86 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -195,7 +195,7 @@ remove_dependencies() {
             ZYPPER_OPTIONS="--non-interactive"
             # zypper version 7.4 got support for automatically removing
             # unneeded packages, but only when removing installed packages.
-            if [ $(rpm -qv libzypp) \> 'libzypp-7.4' ]; then
+            if [ $(rpm -qv libzypp) \> 'libzypp-7.39' ]; then
                 ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
             fi
             execute sudo zypper $ZYPPER_OPTIONS remove $SLES_PACKAGES

--- a/chevah_build
+++ b/chevah_build
@@ -173,19 +173,29 @@ remove_dependencies() {
         ;;
         rhel*)
             execute sudo yum -y remove $RHEL_PACKAGES
-            # Nothing else works in all supported RHELs (currently 4 to 7)
-            # for automatically removing packages installed as dependencies.
-            RHEL_LEAVES=`package-cleanup --leaves --quiet 2>/dev/null \
-                | egrep -v ^'Excluding|Finished'`
-            if [ ! -z $RHEL_LEAVES ]; then
-                execute sudo yum -y remove $RHEL_LEAVES
+            if [ $OS \> 'rhel6' ]; then
+                execute sudo yum -y autoremove
+            else
+                # This partially works in RHEL 4 to 6 for automatically
+                # removing packages installed as dependencies.
+                rhel_yum_autoremove() {
+                    RPM_LEAVES=$(package-cleanup --leaves --quiet 2>/dev/null \
+                        | egrep -v ^'Excluding|Finished')
+                    if [ -z "$RPM_LEAVES" ]; then
+                        (exit 0)
+                    else
+                        execute sudo yum -y remove "$RPM_LEAVES"
+                        rhel_autoremove
+                    fi
+                }
+                rhel_yum_autoremove
             fi
         ;;
         sles*)
             ZYPPER_OPTIONS="--non-interactive"
             # zypper version 7.4 got support for automatically removing
             # unneeded packages, but only when removing installed packages.
-            if [ `rpm -qv libzypp` \> 'libzypp-7.4' ]; then
+            if [ $(rpm -qv libzypp) \> 'libzypp-7.4' ]; then
                 ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
             fi
             execute sudo zypper $ZYPPER_OPTIONS remove $SLES_PACKAGES

--- a/chevah_build
+++ b/chevah_build
@@ -15,6 +15,8 @@
 UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4"
 RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4"
 SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel m4"
+# Currently, we use Debian 7 as a generic Linux distro.
+LINUX_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4"
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
@@ -139,6 +141,10 @@ install_dependencies() {
             packages=$SLES_PACKAGES
             install_command='sudo zypper --non-interactive install -l'
         ;;
+        linux*)
+            packages=$LINUX_PACKAGES
+            install_command='sudo apt-get install -y'
+        ;;
         aix*)
             # For the moment, we don't install anything on AIX.
             packages=""
@@ -180,6 +186,9 @@ remove_dependencies() {
         ;;
         sles*)
             execute sudo zypper --non-interactive remove $SLES_PACKAGES
+        ;;
+        linux*)
+            execute sudo apt-get remove -y --purge $LINUX_PACKAGES
         ;;
     esac
 }

--- a/chevah_build
+++ b/chevah_build
@@ -203,6 +203,9 @@ help_text_build="Create the Python binaries for current OS."
 command_build() {
     install_dependencies
 
+    # Clean the install sub-directory to avoid contamination.
+    rm -rf ${INSTALL_FOLDER}/*
+
     case $OS in
         aix*)
             build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}

--- a/chevah_build
+++ b/chevah_build
@@ -342,8 +342,10 @@ help_text_test=\
 "Run a quick test for the Python from build."
 command_test() {
     test_file='test_python_binary_dist.py'
+    test_file_helper='test_binaries_deps.sh'
     execute mkdir -p build/
     execute cp python-modules/chevah-python-test/${test_file} build/
+    execute cp python-modules/chevah-python-test/${test_file_helper} build/
     execute pushd build
     execute ./$LOCAL_PYTHON_BINARY_DIST/bin/python ${test_file}
     execute popd

--- a/chevah_build
+++ b/chevah_build
@@ -213,8 +213,8 @@ help_text_build="Create the Python binaries for current OS."
 command_build() {
     install_dependencies
 
-    # Clean the install sub-directory to avoid contamination.
-    rm -rf ${INSTALL_FOLDER}/*
+    # Clean the build sub-directory to avoid contamination.
+    command_clean
 
     case $OS in
         aix*)

--- a/chevah_build
+++ b/chevah_build
@@ -14,9 +14,12 @@
 # List of OS packages required for building Python.
 UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4 texinfo"
 RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4 texinfo"
-SLES_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4 texinfo"
-# Currently, we use Debian 7 as a generic Linux distro.
-LINUX_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4 texinfo"
+SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel m4 texinfo"
+# For the moment, we don't install anything on OS X, Solaris, AIX and
+# unsupported Linux distros. The build requires a C compiler, GNU make, m4,
+# makeinfo (from texinfo) and the header files for OpenSSL, zlib and bzip2.
+# On platforms with a choice of C compilers, you may choose among them by
+# setting/unsetting CC and CXX in paver.sh.
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
@@ -142,22 +145,7 @@ install_dependencies() {
             install_command='sudo zypper --non-interactive install
                 --auto-agree-with-licenses'
         ;;
-        linux*)
-            packages=$LINUX_PACKAGES
-            install_command='sudo apt-get -y install'
-        ;;
-        aix*)
-            # For the moment, we don't install anything on AIX.
-            packages=""
-            install_command=''
-        ;;
-        solaris*)
-            # For the moment, we don't install anything on Solaris.
-            packages=""
-            install_command=''
-        ;;
-        osx*)
-            # For the moment, we don't install anything on OSX.
+        linux*|aix*|solaris*|osx*)
             packages=""
             install_command=''
         ;;
@@ -185,10 +173,13 @@ remove_dependencies() {
         ;;
         rhel*)
             execute sudo yum -y remove $RHEL_PACKAGES
-            # Nothing else works in all supported RHELs (currently 4 to 7).
+            # Nothing else works in all supported RHELs (currently 4 to 7)
+            # for automatically removing packages installed as dependencies.
             RHEL_LEAVES=`package-cleanup --leaves --quiet 2>/dev/null \
                 | egrep -v ^'Excluding|Finished'`
-            execute sudo yum -y remove $RHEL_LEAVES
+            if [ ! -z $RHEL_LEAVES ]; then
+                execute sudo yum -y remove $RHEL_LEAVES
+            fi
         ;;
         sles*)
             ZYPPER_OPTIONS="--non-interactive"
@@ -198,10 +189,6 @@ remove_dependencies() {
                 ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
             fi
             execute sudo zypper $ZYPPER_OPTIONS remove $SLES_PACKAGES
-        ;;
-        linux*)
-            execute sudo apt-get -y --purge remove $LINUX_PACKAGES
-            execute sudo apt-get -y --purge autoremove
         ;;
     esac
 }

--- a/chevah_build
+++ b/chevah_build
@@ -12,12 +12,12 @@
 . ./functions.sh
 
 # List of OS packages required for building Python.
-UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4 texinfo"
-RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4 texinfo"
-SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel m4 texinfo"
+UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev m4 texinfo"
+RHEL_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
+SLES_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
 # For the moment, we don't install anything on OS X, Solaris, AIX and
 # unsupported Linux distros. The build requires a C compiler, GNU make, m4,
-# makeinfo (from texinfo) and the header files for OpenSSL, zlib and bzip2.
+# makeinfo (from texinfo, optional) and the header files for OpenSSL and zlib.
 # On platforms with a choice of C compilers, you may choose among them by
 # setting/unsetting CC and CXX in paver.sh.
 

--- a/chevah_build
+++ b/chevah_build
@@ -355,7 +355,7 @@ help_text_test=\
 "Run a quick test for the Python from build."
 command_test() {
     test_file='test_python_binary_dist.py'
-    test_file_helper='test_binaries_deps.sh'
+    test_file_helper='get_binaries_deps.sh'
     execute mkdir -p build/
     execute cp python-modules/chevah-python-test/${test_file} build/
     execute cp python-modules/chevah-python-test/${test_file_helper} build/

--- a/chevah_build
+++ b/chevah_build
@@ -12,11 +12,11 @@
 . ./functions.sh
 
 # List of OS packages required for building Python.
-UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4"
-RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4"
-SLES_PACKAGES="gcc openssl-devel zlib-devel libbz2-devel m4"
+UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4 texinfo"
+RHEL_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4 texinfo"
+SLES_PACKAGES="gcc openssl-devel zlib-devel bzip2-devel m4 texinfo"
 # Currently, we use Debian 7 as a generic Linux distro.
-LINUX_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4"
+LINUX_PACKAGES="gcc libssl-dev zlib1g-dev libbz2-dev m4 texinfo"
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
@@ -131,19 +131,20 @@ install_dependencies() {
     case $OS in
         ubuntu*)
             packages=$UBUNTU_PACKAGES
-            install_command='sudo apt-get install -y'
+            install_command='sudo apt-get -y install'
         ;;
         rhel*)
             packages=$RHEL_PACKAGES
-            install_command='sudo yum install -y'
+            install_command='sudo yum -y install'
         ;;
         sles*)
             packages=$SLES_PACKAGES
-            install_command='sudo zypper --non-interactive install -l'
+            install_command='sudo zypper --non-interactive install
+                --auto-agree-with-licenses'
         ;;
         linux*)
             packages=$LINUX_PACKAGES
-            install_command='sudo apt-get install -y'
+            install_command='sudo apt-get -y install'
         ;;
         aix*)
             # For the moment, we don't install anything on AIX.
@@ -179,16 +180,28 @@ install_dependencies() {
 remove_dependencies() {
     case $OS in
         ubuntu*)
-            execute sudo apt-get remove -y --purge $UBUNTU_PACKAGES
+            execute sudo apt-get -y --purge remove $UBUNTU_PACKAGES
+            execute sudo apt-get -y --purge autoremove
         ;;
         rhel*)
-            execute sudo yum remove -y $RHEL_PACKAGES
+            execute sudo yum -y remove $RHEL_PACKAGES
+            # Nothing else works in all supported RHELs (currently 4 to 7).
+            RHEL_LEAVES=`package-cleanup --leaves --quiet 2>/dev/null \
+                | egrep -v ^'Excluding|Finished'`
+            execute sudo yum -y remove $RHEL_LEAVES
         ;;
         sles*)
-            execute sudo zypper --non-interactive remove $SLES_PACKAGES
+            ZYPPER_OPTIONS="--non-interactive"
+            # zypper version 7.4 got support for automatically removing
+            # unneeded packages, but only when removing installed packages.
+            if [ `rpm -qv libzypp` \> 'libzypp-7.4' ]; then
+                ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
+            fi
+            execute sudo zypper $ZYPPER_OPTIONS remove $SLES_PACKAGES
         ;;
         linux*)
-            execute sudo apt-get remove -y --purge $LINUX_PACKAGES
+            execute sudo apt-get -y --purge remove $LINUX_PACKAGES
+            execute sudo apt-get -y --purge autoremove
         ;;
     esac
 }

--- a/paver.sh
+++ b/paver.sh
@@ -412,7 +412,7 @@ detect_os() {
             if [ "$sles_version" = "11" ] ; then
                 OS='sles11'
             else
-                echo 'Unsuported SLES version.'
+                echo 'Unsupported SLES version.'
                 exit 1
             fi
         elif [ -f /etc/lsb-release ] ; then
@@ -446,18 +446,14 @@ detect_os() {
                 OS='osx108'
                 ;;
             *)
-                echo 'Unsuported OS X version:' $osx_version
+                echo 'Unsupported OS X version:' $osx_version
                 exit 1
                 ;;
         esac
 
         ARCH=`uname -m`
-        if [ "$ARCH" != "x86_64" ] ; then
-            echo 'Unsuported OS X architecture:' $ARCH
-            exit 1
-        fi
     else
-        echo 'Unsuported operating system:' $OS
+        echo 'Unsupported operating system:' $OS
         exit 1
     fi
 

--- a/paver.sh
+++ b/paver.sh
@@ -447,7 +447,7 @@ detect_os() {
 
     else
         echo 'Unsupported operating system:' $OS
-        exit 69
+        exit 14
     fi
 
     # Fix arch names.

--- a/paver.sh
+++ b/paver.sh
@@ -159,7 +159,8 @@ update_path_variables() {
 
 
 write_default_values() {
-    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} ${CC} ${CXX} > DEFAULT_VALUES
+    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} ${CC} ${CXX} \
+        > DEFAULT_VALUES
 }
 
 

--- a/paver.sh
+++ b/paver.sh
@@ -360,7 +360,7 @@ detect_os() {
             exit 13
         fi
 
-        OS="solaris"`echo $sunos_release | cut -b 3-4`
+        OS="solaris"$(echo $sunos_release | cut -d '.' -f 2)
 
     elif [ "${OS}" = "aix" ] ; then
 
@@ -377,7 +377,7 @@ detect_os() {
             exit 13
         fi
 
-        OS="aix"`echo $aix_release | cut -b 1-2`
+        OS="aix"$(echo $aix_release | cut -d '.' -f 1-2 | sed s/\\.//g)
 
     elif [ "${OS}" = "hp-ux" ] ; then
 
@@ -442,7 +442,7 @@ detect_os() {
             echo "OS X version is too old: ${osx_version}."
             exit 13
         else
-            OS="osx`echo $osx_version | cut -b 1-2,4`"
+            OS="osx"$(echo $osx_version | cut -d'.' -f 1-2 | sed s/\\.//g)
         fi
 
     else

--- a/paver.sh
+++ b/paver.sh
@@ -64,13 +64,6 @@ ARCH='x86'
 CC='gcc'
 CXX='g++'
 
-# When run on Linux distros other then those supported by us (Red Hat, SUSE,
-# Ubuntu), we match the LSB distros to the oldest Ubuntu LTS supported by us.
-# For non-LSB distros we use the oldest supported Linux distro. No guarantees
-# made... For details, please see the Linux bits in detect_os() below.
-OS_LINUX_LSB='ubuntu1204'
-OS_LINUX_NONLSB='ubuntu1004'
-
 
 clean_build() {
     # Shortcut for clear since otherwise it will depend on python
@@ -441,11 +434,9 @@ detect_os() {
                         exit 1
                     ;;
                 esac
-            else
-                OS=$OS_LINUX_LSB
             fi
         else
-            OS=$OS_LINUX_NONLSB
+            OS='linux'
         fi
 
     elif [ "${OS}" = "darwin" ] ; then

--- a/paver.sh
+++ b/paver.sh
@@ -352,13 +352,15 @@ detect_os() {
         CC="cc"
         CXX="CC"
 
-        OS="solaris"
         ARCH=`isainfo -n`
-        VERSION=`uname -r`
+        sunos_release=`uname -r`
 
-        if [ "$VERSION" = "5.10" ] ; then
-            OS="solaris10"
+        if [ "$sunos_release" \< "5.10" ] ; then
+            echo "Solaris version is too old: ${sunos_release}."
+            exit 13
         fi
+
+        OS="solaris"`echo $sunos_release | cut -b 3-4`
 
     elif [ "${OS}" = "aix" ] ; then
 
@@ -368,20 +370,20 @@ detect_os() {
         CXX="xlC_r"
 
         ARCH="ppc`getconf HARDWARE_BITMODE`"
-        release=`oslevel`
-        case $release in
-            5.3.*)
-                OS='aix53'
-            ;;
-            7.1.*)
-                OS='aix71'
-            ;;
-        esac
+        aix_release=`oslevel`
+
+        if [ "$aix_release" \< "5.3" ] ; then
+            echo "AIX version is too old: ${aix_release}."
+            exit 13
+        fi
+
+        OS="aix"`echo $aix_release | cut -b 1-2`
 
     elif [ "${OS}" = "hp-ux" ] ; then
 
-        OS="hpux"
         ARCH=`uname -m`
+
+        OS="hpux"
 
     elif [ "${OS}" = "linux" ] ; then
 
@@ -395,31 +397,27 @@ detect_os() {
                 cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
             # RHEL4 glibc is not compatible with RHEL 5 and 6.
             rhel_major_version=${rhel_version%%.*}
-            if [ "$rhel_major_version" = "4" ] ; then
-                OS='rhel4'
-            elif [ "$rhel_major_version" = "5" ] ; then
-                OS='rhel5'
-            elif [ "$rhel_major_version" = "6" ] ; then
-                OS='rhel6'
-            elif [ "$rhel_major_version" = "7" ] ; then
-                OS='rhel7'
-            else
-                echo 'Unsupported RHEL version.'
-                exit 1
+            if [ "$rhel_major_version" \< "4" ] ; then
+                echo "RHEL version is too old: ${rhel_version}."
+                exit 13
             fi
+            OS="rhel${rhel_major_version}"
         elif [ -f /etc/SuSE-release ] ; then
             sles_version=`\
                 grep VERSION /etc/SuSE-release | sed s/VERSION\ =\ //`
-            if [ "$sles_version" = "11" ] ; then
-                OS='sles11'
-            else
-                echo 'Unsupported SLES version.'
-                exit 1
+            if [ "$sles_version" \< "11" ] ; then
+                echo "SLES version is too old: ${sles_version}."
+                exit 13
             fi
+            OS="sles${sles_version}"
         elif [ -f /etc/lsb-release ] ; then
             lsb_release_id=$(lsb_release -is)
             if [ $lsb_release_id = Ubuntu ]; then
                 ubuntu_release=`lsb_release -sr`
+                if [ "$ubuntu_release" \< "10.04" ] ; then
+                    echo "Ubuntu version is too old: ${ubuntu_release}"
+                    exit 13
+                fi
                 case $ubuntu_release in
                     '10.04' | '10.10' | '11.04' | '11.10')
                         OS='ubuntu1004'
@@ -430,10 +428,6 @@ detect_os() {
                     '14.04' | '14.10' | '15.04' | '15.10')
                         OS='ubuntu1404'
                     ;;
-                    *)
-                        echo 'Unsupported Ubuntu version.'
-                        exit 1
-                    ;;
                 esac
             fi
         else
@@ -441,21 +435,19 @@ detect_os() {
         fi
 
     elif [ "${OS}" = "darwin" ] ; then
-        osx_version=`sw_vers -productVersion`
-        case $osx_version in
-            10.8*)
-                OS='osx108'
-                ;;
-            *)
-                echo 'Unsupported OS X version:' $osx_version
-                exit 1
-                ;;
-        esac
-
         ARCH=`uname -m`
+
+        osx_version=`sw_vers -productVersion`
+        if [ "$osx_version" \< "10.8" ] ; then
+            echo "OS X version is too old: ${osx_version}."
+            exit 13
+        else
+            OS="osx`echo $osx_version | cut -b 1-2,4`"
+        fi
+
     else
         echo 'Unsupported operating system:' $OS
-        exit 1
+        exit 69
     fi
 
     # Fix arch names.

--- a/paver.sh
+++ b/paver.sh
@@ -438,7 +438,7 @@ detect_os() {
         ARCH=`uname -m`
 
         osx_version=`sw_vers -productVersion`
-        if [ "$osx_version" \< "10.8" ] ; then
+        if [ "$osx_version" \< "10.4" ] ; then
             echo "OS X version is too old: ${osx_version}."
             exit 13
         else

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 
+checker=ldd
+
 # In Solaris 10, make sure we find OpenSSL libs.
 uname -a | grep ^SunOS | grep " 5.10 " \
     && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/sfw/lib/64"
 
+# In OS X, there's no ldd.
+uname | grep ^Darwin > /dev/null \
+    && checker="otool -L"
+
 # This portable invocation of find will get a raw list of linked libs
 # for the current binaries in the 'build' sub-directory.
-raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} \;)
+raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) \
+            -exec $checker {} \;)
 
 # We exclude the eventual occuring lines listing the examined files as we
 # know they start with './' and we select the first field with awk.
 lib_list=$(echo "$raw_list" | grep -v ^\\./ | awk '{print $1}')
 
 # For AIX, the output of ldd is different...
-uname | grep -v AIX > /dev/null \
-    && lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g | cut -d \( -f1)
+uname | egrep ^'AIX|Darwin' > /dev/null \
+    && lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g \
+                | cut -d \( -f1)
 
 # Finally, we sort the list to eliminate duplicates.
 echo "$lib_list" | sort | uniq

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# In Solaris 10, make sure we find OpenSSL libs.
+uname -a | grep ^SunOS | grep " 5.10 " \
+    && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/sfw/lib/64"
+
+# This portable invocation of find will get a raw list of linked libs
+# for the current binaries in the 'build' sub-directory.
+raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} \;)
+
+# We exclude the eventual occuring lines listing the examined files as we
+# know they start with './' and we select the first field with awk.
+lib_list=$(echo "$raw_list" | grep -v ^\\./ | awk '{print $1}')
+
+# For AIX, the output of ldd is different...
+uname | grep -v AIX > /dev/null \
+    && lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g | cut -d \( -f1)
+
+# Finally, we sort the list to eliminate duplicates.
+echo "$lib_list" | sort | uniq

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,34 +1,46 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 checker=ldd
-
-# In Solaris 10, make sure we find OpenSSL libs (both 64/32 binaries).
-uname -a | grep ^SunOS | grep " 5.10 " >/dev/null \
-    && export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/sfw/lib/64:/usr/sfw/lib/"
-
 os=$(uname)
 
 # In OS X, there's no ldd.
-[ "$os" = "Darwin" ] \
-    && checker="otool -L"
+if [ "$os" = "Darwin" ]; then
+    checker="otool -L"
+fi
+
+# In Solaris 10, make sure we find the OpenSSL libs (both 64/32 binaries).
+if [ "$os" = "SunOS" ]; then
+    # We need a trick to avoid "unbound variables" errors with "set -o nounset".
+    # https://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/sfw/lib/64:/usr/sfw/lib/"
+fi
 
 # This portable invocation of find will get a raw list of linked libs
-# for the current binaries in the 'build' sub-directory.
+# for the current binaries in the current sub-directory: 'build'.
 raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) \
             -exec $checker {} \;)
 
-# We exclude the eventual occuring lines listing the examined files as we
-# know they start with './' and we select the first field with awk.
+# We exclude any occuring lines listing the examined files as we
+# know they start with './' and we select the first fields with awk.
 lib_list=$(echo "$raw_list" | grep -v ^\\./ | awk '{print $1}')
 
-# For AIX and OS X, the output includes the full path. More so, some AIX 5.x
-# libs from /usr/lib/ have moved to /lib in newer versions of AIX.
-[ "$os" = "AIX" ] \
-    && lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g \
+# For AIX and OS X, the output includes the full path. More so, some
+# AIX 5.x libs from /usr/lib/ have moved to /lib in newer AIX versions.
+if [ "$os" = "AIX" ]; then
+    >&2 echo -n "Beware that in AIX we cut /lib/ and /usr/lib/ prefixes from the "
+    >&2 echo    "full paths to the libs in the list."
+    lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g \
                 | cut -d \( -f1)
-[ "$os" = "Darwin" ] \
-    && lib_list=$(echo "$lib_list" | sed s#/System/Library/Frameworks/##g \
-    | sed s#^/usr/lib/##g)
+elif [ "$os" = "Darwin" ]; then
+    >&2 echo -n "Beware that in OS X we cut /System/Library/Frameworks/ and "
+    >&2 echo    "/usr/lib/ prefixes from the full paths to the libs in the list."
+    lib_list=$(echo "$lib_list" | sed s#/System/Library/Frameworks/##g \
+                | sed s#^/usr/lib/##g)
+fi
 
-# Finally, we sort the list to eliminate duplicates.
+# Finally, we sort the list to remove duplicates.
 echo "$lib_list" | sort | uniq

--- a/python-modules/chevah-python-test/test_binaries_deps.sh
+++ b/python-modules/chevah-python-test/test_binaries_deps.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} \; \
-    | grep -v ^\\./ | awk '{print $1}' | sort | uniq | sort

--- a/python-modules/chevah-python-test/test_binaries_deps.sh
+++ b/python-modules/chevah-python-test/test_binaries_deps.sh
@@ -1,2 +1,3 @@
-find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} + \
+#!/usr/bin/env bash
+find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} \; \
     | grep -v ^\\./ | awk '{print $1}' | sort | uniq | sort

--- a/python-modules/chevah-python-test/test_binaries_deps.sh
+++ b/python-modules/chevah-python-test/test_binaries_deps.sh
@@ -1,0 +1,2 @@
+find ./ -type f \( -name "python" -o -name "*.so" \) -exec ldd {} + \
+    | grep -v ^\\./ | awk '{print $1}' | sort | uniq | sort

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -32,7 +32,7 @@ def set_expected_deps():
             'linux-gate.so',
             'linux-vdso.so',
             ]
-        # Distro-specific additional deps. Now we may use the major versions.
+        # Distro-specific deps to add. Now we may specify major versions too.
         linux_distro_name = platform.linux_distribution()[0]
         if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
             expected_deps.extend([
@@ -61,7 +61,7 @@ def set_expected_deps():
                 ])
     # AIX specific deps.
     elif platform_system == 'aix':
-        # This is the standard list of deps for AIX 5 to AIX 7.
+        # This is the standard list of deps for AIX 5.3.
         expected_deps = [
             '/unix',
             'libbsd.a',
@@ -73,10 +73,15 @@ def set_expected_deps():
             'libpthreads.a',
             'libpthreads_compat.a',
             'libssl.a',
-            'libthread.a',
             'libtli.a',
             'libz.a',
             ]
+        # sys.platform could be 'aix5', 'aix6' etc.
+        aix_version = int(sys.platform[-1])
+        if aix_version >= 7:
+            expected_deps.extend([
+                'libthread.a',
+            ])
     # Solaris specific deps.
     elif platform_system == 'sunos':
         # This is the standard list of deps for a Solaris 10 build.
@@ -247,7 +252,7 @@ def main():
             exit_code = 1
 
     if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
-        # On Linux/Unix we need spwd, but not on AIX.
+        # On Linux and Solaris we need spwd, but not on AIX or OS X.
         try:
             import spwd
             spwd

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -154,18 +154,16 @@ if platform_system == 'linux':
         # each of them in any dep from the list of expected deps.
         # This is so that an actual dep of libssl.so.0.9.8 or libssl.so.1.0.0
         # matches an expected dep of libssl.so when checking for OpenSSL.
-        unexpected_deps = []
+        unwanted_deps = []
         for single_actual_dep in actual_deps:
-            found_dep = ""
             for single_expected_dep in expected_deps:
                 if single_expected_dep in single_actual_dep:
-                    found_dep = single_expected_dep
                     break
-            if not found_dep:
-                unexpected_deps.append(single_actual_dep)
-        if unexpected_deps:
-            print "Got unexpected deps:"
-            for single_dep_to_print in unexpected_deps:
+            else:
+                unwanted_deps.append(single_actual_dep)
+        if unwanted_deps:
+            print "Got unwanted deps:"
+            for single_dep_to_print in unwanted_deps:
                 print "\t" , single_dep_to_print
             exit_code=14
 

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -98,11 +98,4 @@ if platform_system == 'linux':
         print 'spwd missing.'
         exit_code = 1
 
-    try:
-        import bz2
-        bz2
-    except:
-        print '"bz2" missing.'
-        exit_code = 1
-
 sys.exit(exit_code)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import platform
+import subprocess
 platform_system = platform.system().lower()
 exit_code = 0
 
@@ -99,22 +100,7 @@ if platform_system == 'linux':
         exit_code = 1
 
     # We compare the deps of the new binaries with a minimal list of deps:
-    # glibc 2.x, openssl 1.0.x and zlib 1.0.x.
-    import subprocess
-    expected_deps = [ \
-        "/lib/ld-linux.so.2", \
-        "libc.so.6", \
-        "libcrypt.so.1", \
-        "libcrypto.so.1", \
-        "libdl.so.2", \
-        "libm.so.6", \
-        "libnsl.so.1", \
-        "libpthread.so.0", \
-        "libssl.so.1", \
-        "libutil.so.1", \
-        "libz.so.1", \
-        "linux-gate.so.1", \
-        ]
+    # glibc, openssl and zlib.
     try:
         actual_deps = subprocess.check_output("./test_binaries_deps.sh", \
             shell=True).split()
@@ -122,23 +108,37 @@ if platform_system == 'linux':
         print "Couldn't determine the deps for the new binaries."
         exit_code = 13
     else:
+        expected_deps = [ \
+            "ld-linux", \
+            "libc.so", \
+            "libcrypt.so", \
+            "libcrypto.so", \
+            "libdl.so", \
+            "libm.so", \
+            "libnsl.so", \
+            "libpthread.so", \
+            "libssl.so", \
+            "libutil.so", \
+            "libz.so", \
+            "linux-gate.so", \
+            ]
         # We check actual deps one by one to see if there is a substring of
         # each of them in any dep from the list of expected deps.
-        # This is so that an actual dep of libcrypto.so.1.0.0 matches an
-        # expected dep of libcrypt.so.1 when checking for OpenSSL 1.0.x.
+        # This is so that an actual dep of libssl.so.0.9.8 or libssl.so.1.0.0
+        # matches an expected dep of libssl.so when checking for OpenSSL.
         unexpected_deps = []
-        for actual_dep in actual_deps:
+        for single_actual_dep in actual_deps:
             found_dep = ""
-            for expected_dep in expected_deps:
-                if expected_dep in actual_dep:
-                    found_dep = expected_dep
+            for single_expected_dep in expected_deps:
+                if single_expected_dep in single_actual_dep:
+                    found_dep = single_expected_dep
                     break
             if not found_dep:
-                unexpected_deps.append(actual_dep)
+                unexpected_deps.append(single_actual_dep)
         if unexpected_deps:
             print "Got unexpected deps:"
-            for dep_to_print in unexpected_deps:
-                print "\t" , dep_to_print
+            for single_dep_to_print in unexpected_deps:
+                print "\t" , single_dep_to_print
             exit_code=14
 
 sys.exit(exit_code)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -9,7 +9,7 @@ platform_system = platform.system().lower()
 exit_code = 0
 
 
-def get_expected_deps():
+def set_expected_deps():
     """
     Here we hardcode the list of expected deps for every supported OS.
     """
@@ -61,14 +61,13 @@ def get_expected_deps():
                 ])
     # AIX specific deps.
     elif platform_system == 'aix':
-        # This is the standard list of deps for AIX 5-7.
+        # This is the standard list of deps for AIX 5 to AIX 7.
         expected_deps = [
             '/unix',
             'libbsd.a',
             'libc.a',
             'libcrypt.a',
             'libcrypto.a',
-            'libcurses.a',
             'libdl.a',
             'libnsl.a',
             'libpthreads.a',
@@ -83,12 +82,10 @@ def get_expected_deps():
         # This is the standard list of deps for a Solaris 10 build.
         expected_deps = [
             'libaio.so.1',
-            'libbz2.so.1',
             'libc.so.1',
             'libcrypt_i.so.1',
             'libcrypto.so.0.9.7',
             'libcrypto_extra.so.0.9.7',
-            'libcurses.so.1',
             'libdl.so.1',
             'libdoor.so.1',
             'libgen.so.1',
@@ -97,7 +94,6 @@ def get_expected_deps():
             'libmd.so.1',
             'libmp.so.2',
             'libnsl.so.1',
-            'libpanel.so.1',
             'librt.so.1',
             'libscf.so.1',
             'libsocket.so.1',
@@ -109,14 +105,16 @@ def get_expected_deps():
             ]
     # OS X specific deps.
     elif platform_system == 'darwin':
-        # This is the minimum list of deps for OS X 10.8.
+        # This is the minimum list of deps for OS X.
         expected_deps = [
+            'ApplicationServices.framework/Versions/A/ApplicationServices',
+            'Carbon.framework/Versions/A/Carbon',
+            'CoreFoundation.framework/Versions/A/CoreFoundation',
+            'CoreServices.framework/Versions/A/CoreServices',
+            'SystemConfiguration.framework/Versions/A/SystemConfiguration',
             'libSystem.B.dylib',
-            'libbz2.1.0.dylib',
             'libcrypto.0.9.8.dylib',
-            'libncurses.5.4.dylib',
-            'libpanel.5.4.dylib',
-            'libsqlite3.dylib',
+            'libgcc_s.1.dylib',
             'libssl.0.9.8.dylib',
             'libz.1.dylib',
             ]
@@ -127,8 +125,9 @@ def get_actual_deps():
     """
     Here we get the list of actual deps using a shell script helper.
     """
+    global exit_code
     try:
-        actual_deps = subprocess.check_output('./get_binaries_deps.sh', \
+        actual_deps = subprocess.check_output('./get_binaries_deps.sh',
                       shell=True).split()
     except:
         print 'Could not determine the deps for the new binaries.'
@@ -144,6 +143,7 @@ def check_deps(expected_deps, actual_deps):
     actual dep of libssl.so.0.9.8 or libssl.so.1.0.0 matches an expected dep of
     libssl.so when checking for OpenSSL.
     """
+    global exit_code
     unwanted_deps = []
     for single_actual_dep in actual_deps:
         for single_expected_dep in expected_deps:
@@ -158,10 +158,12 @@ def check_deps(expected_deps, actual_deps):
         exit_code = 15
 
 
-def main(exit_code):
+def main():
     """
     Main function.
     """
+    global exit_code
+
     try:
         import zlib
         zlib
@@ -244,7 +246,7 @@ def main(exit_code):
             print '"ctypes - windll" missing.'
             exit_code = 1
 
-    if platform_system != 'aix':
+    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
         # On Linux/Unix we need spwd, but not on AIX.
         try:
             import spwd
@@ -255,7 +257,7 @@ def main(exit_code):
 
     # Finally, we compare the list of expected deps for the current OS with the
     # list of actual deps returned by the shell script helper.
-    expected_deps = get_expected_deps()
+    expected_deps = set_expected_deps()
     actual_deps = get_actual_deps()
     if not actual_deps:
         print 'List of deps is empty.'
@@ -266,4 +268,4 @@ def main(exit_code):
     sys.exit(exit_code)
 
 if __name__ == '__main__':
-    main(exit_code)
+    main()

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -79,7 +79,7 @@ def get_expected_deps():
             'libz.a',
             ]
     # Solaris specific deps.
-    elif platform_system == 'solaris':
+    elif platform_system == 'sunos':
         # This is the standard list of deps for a Solaris 10 build.
         expected_deps = [
             'libaio.so.1',
@@ -106,6 +106,19 @@ def get_expected_deps():
             'libssl_extra.so.0.9.7',
             'libuutil.so.1',
             'libz.so.1',
+            ]
+    # OS X specific deps.
+    elif platform_system == 'darwin':
+        # This is the minimum list of deps for OS X 10.8.
+        expected_deps = [
+            'libSystem.B.dylib',
+            'libbz2.1.0.dylib',
+            'libcrypto.0.9.8.dylib',
+            'libncurses.5.4.dylib',
+            'libpanel.5.4.dylib',
+            'libsqlite3.dylib',
+            'libssl.0.9.8.dylib',
+            'libz.1.dylib',
             ]
     return expected_deps
 

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -103,25 +103,53 @@ if platform_system == 'linux':
     # glibc, openssl and zlib.
     try:
         actual_deps = subprocess.check_output("./test_binaries_deps.sh", \
-            shell=True).split()
+                      shell=True).split()
     except:
         print "Couldn't determine the deps for the new binaries."
         exit_code = 13
     else:
-        expected_deps = [ \
-            "ld-linux", \
-            "libc.so", \
-            "libcrypt.so", \
-            "libcrypto.so", \
-            "libdl.so", \
-            "libm.so", \
-            "libnsl.so", \
-            "libpthread.so", \
-            "libssl.so", \
-            "libutil.so", \
-            "libz.so", \
-            "linux-gate.so", \
+        expected_deps = [
+            "ld-linux",
+            "libc.so",
+            "libcrypt.so",
+            "libcrypto.so",
+            "libdl.so",
+            "libm.so",
+            "libnsl.so",
+            "libpthread.so",
+            "libssl.so",
+            "libutil.so",
+            "libz.so",
+            "linux-gate.so",
+            "linux-vdso.so",
             ]
+        # Distro-specific deps. Now we may specify the major versions too.
+        linux_distro_name = platform.linux_distribution()[0]
+        if ("Red Hat" in linux_distro_name) or ("CentOS" in linux_distro_name):
+            expected_deps.extend([
+                "libcom_err.so.2",
+                "libgssapi_krb5.so.2",
+                "libk5crypto.so.3",
+                "libkrb5.so.3",
+                "libresolv.so.2",
+                ])
+            rhel_version = int(platform.linux_distribution()[1].split('.')[0])
+            if rhel_version >= 5:
+                expected_deps.extend([
+                    "libkeyutils.so.1",
+                    "libkrb5support.so.0",
+                    "libselinux.so.1",
+                    "libsepol.so.1",
+                ])
+            if rhel_version >= 6:
+                expected_deps.extend([
+                    "libfreebl3.so",
+                ])
+            if rhel_version >= 7:
+                expected_deps.extend([
+                    "liblzma.so.5",
+                    "libpcre.so.1",
+                ])
         # We check actual deps one by one to see if there is a substring of
         # each of them in any dep from the list of expected deps.
         # This is so that an actual dep of libssl.so.0.9.8 or libssl.so.1.0.0

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -4,167 +4,253 @@ import os
 import sys
 import platform
 import subprocess
+
 platform_system = platform.system().lower()
 exit_code = 0
 
-try:
-    import zlib
-    zlib
-except:
-    print '"zlib" missing.'
-    exit_code = 1
 
-try:
-    import _hashlib
-    _hashlib
-except:
-    print 'standard "ssl" missing.'
-    exit_code = 1
-
-try:
-    from OpenSSL import SSL, crypto, rand
-    SSL
-    crypto
-    rand
-except:
-    print '"OpenSSL" missing.'
-    exit_code = 1
-
-try:
-    import Crypto
-    Crypto
-except:
-    print '"PyCrypto" missing.'
-    exit_code = 1
-
-
-try:
-    import crypt
-    crypt
-except:
-    print '"crypt" missing.'
-    exit_code = 1
-
-try:
-    import pysqlite2
-    pysqlite2
-except:
-    print '"pysqlite2" missing.'
-    exit_code = 1
-
-try:
-    import setproctitle
-    setproctitle
-except:
-    print '"setproctitle" missing.'
-    exit_code = 1
-
-try:
-    from ctypes import CDLL
-    CDLL
-except:
-    print '"ctypes - CDLL" missing.'
-    exit_code = 1
-
-try:
-    from ctypes.util import find_library
-    find_library
-except:
-    print '"ctypes.utils - find_library" missing.'
-    exit_code = 1
-
-try:
-    from Crypto.PublicKey import _fastmath
-    _fastmath
-except:
-    print 'Crypto.PublicKey._fastmath missing. No GMP?'
-    exit_code = 1
-
-# Windows specific modules.
-if os.name == 'nt':
-    try:
-        from ctypes import windll
-        windll
-    except:
-        print '"ctypes - windll" missing.'
-        exit_code = 1
-
-# Linux specific modules.
-if platform_system == 'linux':
-    # On Linux we need spwd... but not on all Unix system, ex: AIX
-    try:
-        import spwd
-        spwd
-    except:
-        print 'spwd missing.'
-        exit_code = 1
-
-    # We compare the deps of the new binaries with a minimal list of deps:
-    # glibc, openssl and zlib.
-    try:
-        actual_deps = subprocess.check_output("./test_binaries_deps.sh", \
-                      shell=True).split()
-    except:
-        print "Couldn't determine the deps for the new binaries."
-        exit_code = 13
-    else:
+def get_expected_deps():
+    """
+    Here we hardcode the list of expected deps for every supported OS.
+    """
+    # Linux specific deps.
+    if platform_system == 'linux':
+        # The minimal list of deps covering Debian, Ubuntu and SUSE:
+        # glibc, openssl and zlib.
         expected_deps = [
-            "ld-linux",
-            "libc.so",
-            "libcrypt.so",
-            "libcrypto.so",
-            "libdl.so",
-            "libm.so",
-            "libnsl.so",
-            "libpthread.so",
-            "libssl.so",
-            "libutil.so",
-            "libz.so",
-            "linux-gate.so",
-            "linux-vdso.so",
+            'ld-linux',
+            'libc.so',
+            'libcrypt.so',
+            'libcrypto.so',
+            'libdl.so',
+            'libm.so',
+            'libnsl.so',
+            'libpthread.so',
+            'libssl.so',
+            'libutil.so',
+            'libz.so',
+            'linux-gate.so',
+            'linux-vdso.so',
             ]
-        # Distro-specific deps. Now we may specify the major versions too.
+        # Distro-specific additional deps. Now we may use the major versions.
         linux_distro_name = platform.linux_distribution()[0]
-        if ("Red Hat" in linux_distro_name) or ("CentOS" in linux_distro_name):
+        if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
             expected_deps.extend([
-                "libcom_err.so.2",
-                "libgssapi_krb5.so.2",
-                "libk5crypto.so.3",
-                "libkrb5.so.3",
-                "libresolv.so.2",
+                'libcom_err.so.2',
+                'libgssapi_krb5.so.2',
+                'libk5crypto.so.3',
+                'libkrb5.so.3',
+                'libresolv.so.2',
                 ])
             rhel_version = int(platform.linux_distribution()[1].split('.')[0])
             if rhel_version >= 5:
                 expected_deps.extend([
-                    "libkeyutils.so.1",
-                    "libkrb5support.so.0",
-                    "libselinux.so.1",
-                    "libsepol.so.1",
+                    'libkeyutils.so.1',
+                    'libkrb5support.so.0',
+                    'libselinux.so.1',
+                    'libsepol.so.1',
                 ])
             if rhel_version >= 6:
                 expected_deps.extend([
-                    "libfreebl3.so",
+                    'libfreebl3.so',
                 ])
             if rhel_version >= 7:
                 expected_deps.extend([
-                    "liblzma.so.5",
-                    "libpcre.so.1",
+                    'liblzma.so.5',
+                    'libpcre.so.1',
                 ])
-        # We check actual deps one by one to see if there is a substring of
-        # each of them in any dep from the list of expected deps.
-        # This is so that an actual dep of libssl.so.0.9.8 or libssl.so.1.0.0
-        # matches an expected dep of libssl.so when checking for OpenSSL.
-        unwanted_deps = []
-        for single_actual_dep in actual_deps:
-            for single_expected_dep in expected_deps:
-                if single_expected_dep in single_actual_dep:
-                    break
-            else:
-                unwanted_deps.append(single_actual_dep)
-        if unwanted_deps:
-            print "Got unwanted deps:"
-            for single_dep_to_print in unwanted_deps:
-                print "\t" , single_dep_to_print
-            exit_code=14
+    # AIX specific deps.
+    elif platform_system == 'aix':
+        # This is the standard list of deps for AIX 5-7.
+        expected_deps = [
+            '/unix',
+            'libbsd.a',
+            'libc.a',
+            'libcrypt.a',
+            'libcrypto.a',
+            'libcurses.a',
+            'libdl.a',
+            'libnsl.a',
+            'libpthreads.a',
+            'libpthreads_compat.a',
+            'libssl.a',
+            'libthread.a',
+            'libtli.a',
+            'libz.a',
+            ]
+    # Solaris specific deps.
+    elif platform_system == 'solaris':
+        # This is the standard list of deps for a Solaris 10 build.
+        expected_deps = [
+            'libaio.so.1',
+            'libbz2.so.1',
+            'libc.so.1',
+            'libcrypt_i.so.1',
+            'libcrypto.so.0.9.7',
+            'libcrypto_extra.so.0.9.7',
+            'libcurses.so.1',
+            'libdl.so.1',
+            'libdoor.so.1',
+            'libgen.so.1',
+            'libintl.so.1',
+            'libm.so.2',
+            'libmd.so.1',
+            'libmp.so.2',
+            'libnsl.so.1',
+            'libpanel.so.1',
+            'librt.so.1',
+            'libscf.so.1',
+            'libsocket.so.1',
+            'libsqlite3.so.0',
+            'libssl.so.0.9.7',
+            'libssl_extra.so.0.9.7',
+            'libuutil.so.1',
+            'libz.so.1',
+            ]
+    return expected_deps
 
-sys.exit(exit_code)
+
+def get_actual_deps():
+    """
+    Here we get the list of actual deps using a shell script helper.
+    """
+    try:
+        actual_deps = subprocess.check_output('./get_binaries_deps.sh', \
+                      shell=True).split()
+    except:
+        print 'Could not determine the deps for the new binaries.'
+        exit_code = 13
+    else:
+        return actual_deps
+
+
+def check_deps(expected_deps, actual_deps):
+    """
+    We check actual deps one by one to see if there is a substring of each
+    of them in any dep from the list of expected deps. This is so that an
+    actual dep of libssl.so.0.9.8 or libssl.so.1.0.0 matches an expected dep of
+    libssl.so when checking for OpenSSL.
+    """
+    unwanted_deps = []
+    for single_actual_dep in actual_deps:
+        for single_expected_dep in expected_deps:
+            if single_expected_dep in single_actual_dep:
+                break
+        else:
+            unwanted_deps.append(single_actual_dep)
+    if unwanted_deps:
+        print 'Got unwanted deps:'
+        for single_dep_to_print in unwanted_deps:
+            print '\t' , single_dep_to_print
+        exit_code = 15
+
+
+def main(exit_code):
+    """
+    Main function.
+    """
+    try:
+        import zlib
+        zlib
+    except:
+        print '"zlib" missing.'
+        exit_code = 1
+
+    try:
+        import _hashlib
+        _hashlib
+    except:
+        print 'standard "ssl" missing.'
+        exit_code = 1
+
+    try:
+        from OpenSSL import SSL, crypto, rand
+        SSL
+        crypto
+        rand
+    except:
+        print '"OpenSSL" missing.'
+        exit_code = 1
+
+    try:
+        import Crypto
+        Crypto
+    except:
+        print '"PyCrypto" missing.'
+        exit_code = 1
+
+
+    try:
+        import crypt
+        crypt
+    except:
+        print '"crypt" missing.'
+        exit_code = 1
+
+    try:
+        import pysqlite2
+        pysqlite2
+    except:
+        print '"pysqlite2" missing.'
+        exit_code = 1
+
+    try:
+        import setproctitle
+        setproctitle
+    except:
+        print '"setproctitle" missing.'
+        exit_code = 1
+
+    try:
+        from ctypes import CDLL
+        CDLL
+    except:
+        print '"ctypes - CDLL" missing.'
+        exit_code = 1
+
+    try:
+        from ctypes.util import find_library
+        find_library
+    except:
+        print '"ctypes.utils - find_library" missing.'
+        exit_code = 1
+
+    try:
+        from Crypto.PublicKey import _fastmath
+        _fastmath
+    except:
+        print 'Crypto.PublicKey._fastmath missing. No GMP?'
+        exit_code = 1
+
+    # Windows specific modules.
+    if os.name == 'nt':
+        try:
+            from ctypes import windll
+            windll
+        except:
+            print '"ctypes - windll" missing.'
+            exit_code = 1
+
+    if platform_system != 'aix':
+        # On Linux/Unix we need spwd, but not on AIX.
+        try:
+            import spwd
+            spwd
+        except:
+            print 'spwd missing.'
+            exit_code = 1
+
+    # Finally, we compare the list of expected deps for the current OS with the
+    # list of actual deps returned by the shell script helper.
+    expected_deps = get_expected_deps()
+    actual_deps = get_actual_deps()
+    if not actual_deps:
+        print 'List of deps is empty.'
+        exit_code = 14
+    else:
+        check_deps(expected_deps, actual_deps)
+
+    sys.exit(exit_code)
+
+if __name__ == '__main__':
+    main(exit_code)

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -33,7 +33,7 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = []
+disabled_module_list = [ 'bz2', '_tkinter', '_curses' , '_curses_panel', '_sqlite3' ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -33,7 +33,18 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = [ 'bz2', '_tkinter', '_curses' , '_curses_panel', '_sqlite3' ]
+disabled_module_list = [
+                    '_bsddb',
+                    '_curses',
+                    '_curses_panel',
+                    '_sqlite3',
+                    '_tkinter',
+                    'bz2',
+                    'dbm',
+                    'gdbm',
+                    'readline',
+                    'sunaudiodev',
+                    ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.9/setup.py
+++ b/src/python/Python-2.7.9/setup.py
@@ -33,7 +33,7 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = []
+disabled_module_list = [ 'bz2', '_tkinter', '_curses' , '_curses_panel', '_sqlite3' ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.9/setup.py
+++ b/src/python/Python-2.7.9/setup.py
@@ -33,7 +33,17 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = [ 'bz2', '_tkinter', '_curses' , '_curses_panel', '_sqlite3' ]
+disabled_module_list = [
+                    '_bsddb',
+                    '_curses',
+                    '_curses_panel',
+                    '_sqlite3',
+                    '_tkinter',
+                    'bz2',
+                    'dbm',
+                    'gdbm',
+                    'readline',
+                    ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if


### PR DESCRIPTION
Problems?
------------
We don't have an **x86** slave for `server`, `python-package` etc.
We equate unsupported/untested Linux distros with old Ubuntu LTS distros.

Solution?
-------------
Added a Debian 7 **x86** slave for `brink`, `python-package`, `compat`, `empirical`, `watchdog` and `server` and updated `python-package` with generic Linux support

**Drive-by fixes**:
  * added automatic removal of packages installed as dependencies during build in Ubuntu, RHEL and recent SLES distros
  * reshaped OS detection/naming to differentiate among old releases of supported OS'es and unsupported OS'es. Newer releases of supported OS'es shouldn't require any special addition in `paver.sh` from now on
  * removed `libbz2` headers installation
  * clean-up the install sub-directory to avoid contamination of new builds
  * check for unwanted dependencies in Linux, AIX, Solaris and OS X
  * edited `setup.py` to prevent building the following modules: `bz2`, `_tkinter`, `_curses` , `_curses_panel`, `_sqlite3`.

How to test?
----------------
Please review changes.
Run the tests.