### PR TITLE
[#2680] Check unwanted deps.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -355,8 +355,10 @@ help_text_test=\
 "Run a quick test for the Python from build."
 command_test() {
     test_file='test_python_binary_dist.py'
+    test_file_helper='get_binaries_deps.sh'
     execute mkdir -p build/
     execute cp python-modules/chevah-python-test/${test_file} build/
+    execute cp python-modules/chevah-python-test/${test_file_helper} build/
     execute pushd build
     execute ./$LOCAL_PYTHON_BINARY_DIST/bin/python ${test_file}
     execute popd

--- a/chevah_build
+++ b/chevah_build
@@ -355,10 +355,9 @@ help_text_test=\
 "Run a quick test for the Python from build."
 command_test() {
     test_file='test_python_binary_dist.py'
-    test_file_helper='get_binaries_deps.sh'
     execute mkdir -p build/
     execute cp python-modules/chevah-python-test/${test_file} build/
-    execute cp python-modules/chevah-python-test/${test_file_helper} build/
+    execute cp python-modules/chevah-python-test/get_binaries_deps.sh build/
     execute pushd build
     execute ./$LOCAL_PYTHON_BINARY_DIST/bin/python ${test_file}
     execute popd

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+checker=ldd
+os=$(uname)
+
+# In OS X, there's no ldd.
+if [ "$os" = "Darwin" ]; then
+    checker="otool -L"
+fi
+
+# In Solaris 10, make sure we find the OpenSSL libs (both 64/32 binaries).
+if [ "$os" = "SunOS" ]; then
+    # We need a trick to avoid "unbound variables" errors with "set -o nounset".
+    # https://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/sfw/lib/64:/usr/sfw/lib/"
+fi
+
+# This portable invocation of find will get a raw list of linked libs
+# for the current binaries in the current sub-directory: 'build'.
+raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) \
+            -exec $checker {} \;)
+
+# We exclude any occuring lines listing the examined files as we
+# know they start with './' and we select the first fields with awk.
+lib_list=$(echo "$raw_list" | grep -v ^\\./ | awk '{print $1}')
+
+# For AIX and OS X, the output includes the full path. More so, some
+# AIX 5.x libs from /usr/lib/ have moved to /lib in newer AIX versions.
+if [ "$os" = "AIX" ]; then
+    >&2 echo -n "Beware that in AIX we cut /lib/ and /usr/lib/ prefixes from the "
+    >&2 echo    "full paths to the libs in the list."
+    lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g \
+                | cut -d \( -f1)
+elif [ "$os" = "Darwin" ]; then
+    >&2 echo -n "Beware that in OS X we cut /System/Library/Frameworks/ and "
+    >&2 echo    "/usr/lib/ prefixes from the full paths to the libs in the list."
+    lib_list=$(echo "$lib_list" | sed s#/System/Library/Frameworks/##g \
+                | sed s#^/usr/lib/##g)
+fi
+
+# Finally, we sort the list to remove duplicates.
+echo "$lib_list" | sort | uniq

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Outputs a sorted list of dependencies for the python binary and .so files
-# in the current directory and its subdirectories (to be run in 'build/').
+# Uses 'ldd' or equivalents to list all dependencies for the python binary and
+# .so files in the current hierarchy of directories (to be run in 'build/').
 
 set -o nounset
 set -o errexit
@@ -22,5 +22,5 @@ if [ "$os" = "SunOS" ]; then
 fi
 
 # This portable invocation of find will get a raw list of linked libs
-# for the current binaries in the current sub-directory: 'build'.
+# for the current binaries in the current sub-directory, usually 'build'.
 find ./ -type f \( -name "python" -o -name "*.so" \) -exec $checker {} \;

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Outputs a sorted list of dependencies for the python binary and .so files
+# in the current directory and its subdirectories (to be run in 'build/').
+
 set -o nounset
 set -o errexit
 set -o pipefail

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -10,7 +10,6 @@ set -o pipefail
 checker=ldd
 os=$(uname)
 
-# In OS X, there's no ldd.
 if [ "$os" = "Darwin" ]; then
     checker="otool -L"
 fi
@@ -24,26 +23,4 @@ fi
 
 # This portable invocation of find will get a raw list of linked libs
 # for the current binaries in the current sub-directory: 'build'.
-raw_list=$(find ./ -type f \( -name "python" -o -name "*.so" \) \
-            -exec $checker {} \;)
-
-# We exclude any occuring lines listing the examined files as we
-# know they start with './' and we select the first fields with awk.
-lib_list=$(echo "$raw_list" | grep -v ^\\./ | awk '{print $1}')
-
-# For AIX and OS X, the output includes the full path. More so, some
-# AIX 5.x libs from /usr/lib/ have moved to /lib in newer AIX versions.
-if [ "$os" = "AIX" ]; then
-    >&2 echo -n "Beware that in AIX we cut /lib/ and /usr/lib/ prefixes from the "
-    >&2 echo    "full paths to the libs in the list."
-    lib_list=$(echo "$lib_list" | sed s#^/usr##g | sed s#^/lib/##g \
-                | cut -d \( -f1)
-elif [ "$os" = "Darwin" ]; then
-    >&2 echo -n "Beware that in OS X we cut /System/Library/Frameworks/ and "
-    >&2 echo    "/usr/lib/ prefixes from the full paths to the libs in the list."
-    lib_list=$(echo "$lib_list" | sed s#/System/Library/Frameworks/##g \
-                | sed s#^/usr/lib/##g)
-fi
-
-# Finally, we sort the list to remove duplicates.
-echo "$lib_list" | sort | uniq
+find ./ -type f \( -name "python" -o -name "*.so" \) -exec $checker {} \;

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -5,19 +5,19 @@ import sys
 import platform
 import subprocess
 
+script_helper = './get_binaries_deps.sh'
 platform_system = platform.system().lower()
 
 
-def set_expected_deps():
+def get_allowed_deps():
     """
-    Returns a hardcoded list of expected deps for every supported OS.
+    Return a hardcoded list of allowed deps for the current OS.
     """
-    expected_deps = []
-    # Linux specific deps.
+    allowed_deps = []
     if platform_system == 'linux':
         # The minimal list of deps covering Debian, Ubuntu and SUSE:
         # glibc, openssl and zlib.
-        expected_deps = [
+        allowed_deps = [
             'ld-linux',
             'libc.so',
             'libcrypt.so',
@@ -35,7 +35,7 @@ def set_expected_deps():
         # Distro-specific deps to add. Now we may specify major versions too.
         linux_distro_name = platform.linux_distribution()[0]
         if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
-            expected_deps.extend([
+            allowed_deps.extend([
                 'libcom_err.so.2',
                 'libgssapi_krb5.so.2',
                 'libk5crypto.so.3',
@@ -44,25 +44,24 @@ def set_expected_deps():
                 ])
             rhel_version = int(platform.linux_distribution()[1].split('.')[0])
             if rhel_version >= 5:
-                expected_deps.extend([
+                allowed_deps.extend([
                     'libkeyutils.so.1',
                     'libkrb5support.so.0',
                     'libselinux.so.1',
                     'libsepol.so.1',
                 ])
             if rhel_version >= 6:
-                expected_deps.extend([
+                allowed_deps.extend([
                     'libfreebl3.so',
                 ])
             if rhel_version >= 7:
-                expected_deps.extend([
+                allowed_deps.extend([
                     'liblzma.so.5',
                     'libpcre.so.1',
                 ])
-    # AIX specific deps.
     elif platform_system == 'aix':
         # This is the standard list of deps for AIX 5.3.
-        expected_deps = [
+        allowed_deps = [
             '/unix',
             'libbsd.a',
             'libc.a',
@@ -79,14 +78,13 @@ def set_expected_deps():
         # sys.platform could be 'aix5', 'aix6' etc.
         aix_version = int(sys.platform[-1])
         if aix_version >= 7:
-            expected_deps.extend([
+            allowed_deps.extend([
                 'libthread.a',
             ])
-    # Solaris specific deps.
     elif platform_system == 'sunos':
         # This is the standard list of deps for a Solaris 10 build.
         # For now, we include the major versions for Solaris libs.
-        expected_deps = [
+        allowed_deps = [
             'libaio.so.1',
             'libc.so.1',
             'libcrypt_i.so.1',
@@ -109,10 +107,9 @@ def set_expected_deps():
             'libuutil.so.1',
             'libz.so.1',
             ]
-    # OS X specific deps.
     elif platform_system == 'darwin':
         # This is the minimum list of deps for OS X.
-        expected_deps = [
+        allowed_deps = [
             'ApplicationServices.framework/Versions/A/ApplicationServices',
             'Carbon.framework/Versions/A/Carbon',
             'CoreFoundation.framework/Versions/A/CoreFoundation',
@@ -124,43 +121,51 @@ def set_expected_deps():
             'libssl.0.9.8.dylib',
             'libz.1.dylib',
             ]
-    return expected_deps
+    return allowed_deps
 
 
 def get_actual_deps():
     """
-    Returns the list of actual deps obtained using a bash script helper.
+    Return the list of actual deps for the newly-built binaries.
     """
     try:
-        actual_deps = subprocess.check_output('./get_binaries_deps.sh',
-            shell=True).split()
+        raw_deps = subprocess.check_output(script_helper).splitlines()
     except:
-        print 'Could not determine the deps for the new binaries.'
+        sys.stderr.write('Could not get the deps for the new binaries.\n')
     else:
-        return actual_deps
+        libs_deps = []
+        for line in raw_deps:
+            # We exclude any occuring lines listing the examined files as we
+            # know they start with './' (this is a problem in AIX and OS X).
+            if line[:2] != './' :
+                libs_deps.append(line.split()[0])
+        return list(set(libs_deps))
 
 
-def check_deps(expected_deps, actual_deps):
+def get_unwanted_deps(allowed_deps, actual_deps):
     """
-    Returns unwanted deps for the python binary or the .so files in 'build/'.
+    Return unwanted deps for the newly-built binaries.
+    allowed_deps are hardcoded deps for binaries built for the current OS.
+    actual_deps are the deps found for the newly-built binaries.
     """
     # Check actual deps one by one to see if there is a substring of each of
-    # them in any dep from the list of expected deps. This is so that an actual
-    # dep of libssl.so.0.9.8 or libssl.so.1.0.0 matches an expected dep of
+    # them in any dep from the list of allowed deps. This is so that an actual
+    # dep of libssl.so.0.9.8 or libssl.so.1.0.0 matches an allowed dep of
     # libssl.so when checking for OpenSSL.
     unwanted_deps = []
     for single_actual_dep in actual_deps:
-        for single_expected_dep in expected_deps:
-            if single_expected_dep in single_actual_dep:
+        for single_allowed_dep in allowed_deps:
+            if single_allowed_dep in single_actual_dep:
                 break
         else:
             unwanted_deps.append(single_actual_dep)
     return unwanted_deps
 
+
 def main():
     """
-    Launches tests to check required modules and OS-specific dependencies.
-    Exits with a relevant error code.
+    Launch tests to check required modules and OS-specific dependencies.
+    Exit with a relevant error code.
     """
     exit_code = 0
 
@@ -168,15 +173,15 @@ def main():
         import zlib
         zlib
     except:
-        print '"zlib" missing.'
+        sys.stderr.write('"zlib" missing.\n')
         exit_code = 1
 
     try:
         import _hashlib
         _hashlib
     except:
-        print 'standard "ssl" missing.'
-        exit_code = 1
+        sys.stderr.write('standard "ssl" missing.\n')
+        exit_code = 2
 
     try:
         from OpenSSL import SSL, crypto, rand
@@ -184,58 +189,57 @@ def main():
         crypto
         rand
     except:
-        print '"OpenSSL" missing.'
-        exit_code = 1
+        sys.stderr.write('"OpenSSL" missing.\n')
+        exit_code = 3
 
     try:
         import Crypto
         Crypto
     except:
-        print '"PyCrypto" missing.'
-        exit_code = 1
-
+        sys.stderr.write('"PyCrypto" missing.\n')
+        exit_code = 4
 
     try:
         import crypt
         crypt
     except:
-        print '"crypt" missing.'
-        exit_code = 1
+        sys.stderr.write('"crypt" missing.\n')
+        exit_code = 5
 
     try:
         import pysqlite2
         pysqlite2
     except:
-        print '"pysqlite2" missing.'
-        exit_code = 1
+        sys.stderr.write('"pysqlite2" missing.\n')
+        exit_code = 6
 
     try:
         import setproctitle
         setproctitle
     except:
-        print '"setproctitle" missing.'
-        exit_code = 1
+        sys.stderr.write('"setproctitle" missing.\n')
+        exit_code = 7
 
     try:
         from ctypes import CDLL
         CDLL
     except:
-        print '"ctypes - CDLL" missing.'
-        exit_code = 1
+        sys.stderr.write('"ctypes - CDLL" missing.\n')
+        exit_code = 8
 
     try:
         from ctypes.util import find_library
         find_library
     except:
-        print '"ctypes.utils - find_library" missing.'
-        exit_code = 1
+        sys.stderr.write('"ctypes.utils - find_library" missing.\n')
+        exit_code = 9
 
     try:
         from Crypto.PublicKey import _fastmath
         _fastmath
     except:
-        print 'Crypto.PublicKey._fastmath missing. No GMP?'
-        exit_code = 1
+        sys.stderr.write('Crypto.PublicKey._fastmath missing. No GMP?\n')
+        exit_code = 10
 
     # Windows specific modules.
     if os.name == 'nt':
@@ -243,8 +247,8 @@ def main():
             from ctypes import windll
             windll
         except:
-            print '"ctypes - windll" missing.'
-            exit_code = 1
+            sys.stderr.write('"ctypes - windll" missing.\n')
+            exit_code = 11
 
     if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
         # On Linux and Solaris we need spwd, but not on AIX or OS X.
@@ -252,26 +256,28 @@ def main():
             import spwd
             spwd
         except:
-            print 'spwd missing.'
-            exit_code = 1
+            sys.stderr.write('spwd missing.\n')
+            exit_code = 12
 
-    # Finally, compare the list of expected deps for the current OS with the
-    # list of actual deps returned by the shell script helper.
-    expected_deps = set_expected_deps()
-    if not expected_deps:
-        print 'List of expected deps is empty. Unsupported OS?'
+    # Compare the list of allowed deps for the current OS with the list of
+    # actual deps for the newly-built binaries returned by the script helper.
+    allowed_deps = get_allowed_deps()
+    if not allowed_deps:
+        sys.stderr.write('Got no allowed deps. Please check if {0} is a ' \
+            'supported operating system.\n'.format(platform.system()))
         exit_code = 13
     else:
         actual_deps = get_actual_deps()
         if not actual_deps:
-            print 'List of deps is empty. Problems running the script helper?'
+            sys.stderr.write('Got no deps for the new binaries. Please check ' \
+                'the "{0}" script in the "build/" dir.\n'.format(script_helper))
             exit_code = 14
         else:
-            unwanted_deps = check_deps(expected_deps, actual_deps)
+            unwanted_deps = get_unwanted_deps(allowed_deps, actual_deps)
             if unwanted_deps:
-                print 'Got unwanted deps:'
+                sys.stderr.write('Got unwanted deps:\n')
                 for single_dep_to_print in unwanted_deps:
-                    print '\t' , single_dep_to_print
+                    sys.stderr.write('\t{0}\n'.format(single_dep_to_print))
                 exit_code = 15
 
     sys.exit(exit_code)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -3,99 +3,274 @@
 import os
 import sys
 import platform
+import subprocess
+
 platform_system = platform.system().lower()
 exit_code = 0
 
-try:
-    import zlib
-    zlib
-except:
-    print '"zlib" missing.'
-    exit_code = 1
 
-try:
-    import _hashlib
-    _hashlib
-except:
-    print 'standard "ssl" missing.'
-    exit_code = 1
+def set_expected_deps():
+    """
+    Here we hardcode the list of expected deps for every supported OS.
+    """
+    # Linux specific deps.
+    if platform_system == 'linux':
+        # The minimal list of deps covering Debian, Ubuntu and SUSE:
+        # glibc, openssl and zlib.
+        expected_deps = [
+            'ld-linux',
+            'libc.so',
+            'libcrypt.so',
+            'libcrypto.so',
+            'libdl.so',
+            'libm.so',
+            'libnsl.so',
+            'libpthread.so',
+            'libssl.so',
+            'libutil.so',
+            'libz.so',
+            'linux-gate.so',
+            'linux-vdso.so',
+            ]
+        # Distro-specific deps to add. Now we may specify major versions too.
+        linux_distro_name = platform.linux_distribution()[0]
+        if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
+            expected_deps.extend([
+                'libcom_err.so.2',
+                'libgssapi_krb5.so.2',
+                'libk5crypto.so.3',
+                'libkrb5.so.3',
+                'libresolv.so.2',
+                ])
+            rhel_version = int(platform.linux_distribution()[1].split('.')[0])
+            if rhel_version >= 5:
+                expected_deps.extend([
+                    'libkeyutils.so.1',
+                    'libkrb5support.so.0',
+                    'libselinux.so.1',
+                    'libsepol.so.1',
+                ])
+            if rhel_version >= 6:
+                expected_deps.extend([
+                    'libfreebl3.so',
+                ])
+            if rhel_version >= 7:
+                expected_deps.extend([
+                    'liblzma.so.5',
+                    'libpcre.so.1',
+                ])
+    # AIX specific deps.
+    elif platform_system == 'aix':
+        # This is the standard list of deps for AIX 5.3.
+        expected_deps = [
+            '/unix',
+            'libbsd.a',
+            'libc.a',
+            'libcrypt.a',
+            'libcrypto.a',
+            'libdl.a',
+            'libnsl.a',
+            'libpthreads.a',
+            'libpthreads_compat.a',
+            'libssl.a',
+            'libtli.a',
+            'libz.a',
+            ]
+        # sys.platform could be 'aix5', 'aix6' etc.
+        aix_version = int(sys.platform[-1])
+        if aix_version >= 7:
+            expected_deps.extend([
+                'libthread.a',
+            ])
+    # Solaris specific deps.
+    elif platform_system == 'sunos':
+        # This is the standard list of deps for a Solaris 10 build.
+        expected_deps = [
+            'libaio.so.1',
+            'libc.so.1',
+            'libcrypt_i.so.1',
+            'libcrypto.so.0.9.7',
+            'libcrypto_extra.so.0.9.7',
+            'libdl.so.1',
+            'libdoor.so.1',
+            'libgen.so.1',
+            'libintl.so.1',
+            'libm.so.2',
+            'libmd.so.1',
+            'libmp.so.2',
+            'libnsl.so.1',
+            'librt.so.1',
+            'libscf.so.1',
+            'libsocket.so.1',
+            'libsqlite3.so.0',
+            'libssl.so.0.9.7',
+            'libssl_extra.so.0.9.7',
+            'libuutil.so.1',
+            'libz.so.1',
+            ]
+    # OS X specific deps.
+    elif platform_system == 'darwin':
+        # This is the minimum list of deps for OS X.
+        expected_deps = [
+            'ApplicationServices.framework/Versions/A/ApplicationServices',
+            'Carbon.framework/Versions/A/Carbon',
+            'CoreFoundation.framework/Versions/A/CoreFoundation',
+            'CoreServices.framework/Versions/A/CoreServices',
+            'SystemConfiguration.framework/Versions/A/SystemConfiguration',
+            'libSystem.B.dylib',
+            'libcrypto.0.9.8.dylib',
+            'libgcc_s.1.dylib',
+            'libssl.0.9.8.dylib',
+            'libz.1.dylib',
+            ]
+    return expected_deps
 
-try:
-    from OpenSSL import SSL, crypto, rand
-    SSL
-    crypto
-    rand
-except:
-    print '"OpenSSL" missing.'
-    exit_code = 1
 
-try:
-    import Crypto
-    Crypto
-except:
-    print '"PyCrypto" missing.'
-    exit_code = 1
-
-
-try:
-    import crypt
-    crypt
-except:
-    print '"crypt" missing.'
-    exit_code = 1
-
-try:
-    import pysqlite2
-    pysqlite2
-except:
-    print '"pysqlite2" missing.'
-    exit_code = 1
-
-try:
-    import setproctitle
-    setproctitle
-except:
-    print '"setproctitle" missing.'
-    exit_code = 1
-
-try:
-    from ctypes import CDLL
-    CDLL
-except:
-    print '"ctypes - CDLL" missing.'
-    exit_code = 1
-
-try:
-    from ctypes.util import find_library
-    find_library
-except:
-    print '"ctypes.utils - find_library" missing.'
-    exit_code = 1
-
-try:
-    from Crypto.PublicKey import _fastmath
-    _fastmath
-except:
-    print 'Crypto.PublicKey._fastmath missing. No GMP?'
-    exit_code = 1
-
-# Windows specific modules.
-if os.name == 'nt':
+def get_actual_deps():
+    """
+    Here we get the list of actual deps using a shell script helper.
+    """
+    global exit_code
     try:
-        from ctypes import windll
-        windll
+        actual_deps = subprocess.check_output('./get_binaries_deps.sh',
+                      shell=True).split()
     except:
-        print '"ctypes - windll" missing.'
+        print 'Could not determine the deps for the new binaries.'
+        exit_code = 13
+    else:
+        return actual_deps
+
+
+def check_deps(expected_deps, actual_deps):
+    """
+    We check actual deps one by one to see if there is a substring of each
+    of them in any dep from the list of expected deps. This is so that an
+    actual dep of libssl.so.0.9.8 or libssl.so.1.0.0 matches an expected dep of
+    libssl.so when checking for OpenSSL.
+    """
+    global exit_code
+    unwanted_deps = []
+    for single_actual_dep in actual_deps:
+        for single_expected_dep in expected_deps:
+            if single_expected_dep in single_actual_dep:
+                break
+        else:
+            unwanted_deps.append(single_actual_dep)
+    if unwanted_deps:
+        print 'Got unwanted deps:'
+        for single_dep_to_print in unwanted_deps:
+            print '\t' , single_dep_to_print
+        exit_code = 15
+
+
+def main():
+    """
+    Main function.
+    """
+    global exit_code
+
+    try:
+        import zlib
+        zlib
+    except:
+        print '"zlib" missing.'
         exit_code = 1
 
-# Linux specific modules.
-if platform_system == 'linux':
-    # On Linux we need spwd... but not on all Unix system, ex: AIX
     try:
-        import spwd
-        spwd
+        import _hashlib
+        _hashlib
     except:
-        print 'spwd missing.'
+        print 'standard "ssl" missing.'
         exit_code = 1
 
-sys.exit(exit_code)
+    try:
+        from OpenSSL import SSL, crypto, rand
+        SSL
+        crypto
+        rand
+    except:
+        print '"OpenSSL" missing.'
+        exit_code = 1
+
+    try:
+        import Crypto
+        Crypto
+    except:
+        print '"PyCrypto" missing.'
+        exit_code = 1
+
+
+    try:
+        import crypt
+        crypt
+    except:
+        print '"crypt" missing.'
+        exit_code = 1
+
+    try:
+        import pysqlite2
+        pysqlite2
+    except:
+        print '"pysqlite2" missing.'
+        exit_code = 1
+
+    try:
+        import setproctitle
+        setproctitle
+    except:
+        print '"setproctitle" missing.'
+        exit_code = 1
+
+    try:
+        from ctypes import CDLL
+        CDLL
+    except:
+        print '"ctypes - CDLL" missing.'
+        exit_code = 1
+
+    try:
+        from ctypes.util import find_library
+        find_library
+    except:
+        print '"ctypes.utils - find_library" missing.'
+        exit_code = 1
+
+    try:
+        from Crypto.PublicKey import _fastmath
+        _fastmath
+    except:
+        print 'Crypto.PublicKey._fastmath missing. No GMP?'
+        exit_code = 1
+
+    # Windows specific modules.
+    if os.name == 'nt':
+        try:
+            from ctypes import windll
+            windll
+        except:
+            print '"ctypes - windll" missing.'
+            exit_code = 1
+
+    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
+        # On Linux and Solaris we need spwd, but not on AIX or OS X.
+        try:
+            import spwd
+            spwd
+        except:
+            print 'spwd missing.'
+            exit_code = 1
+
+    # Finally, we compare the list of expected deps for the current OS with the
+    # list of actual deps returned by the shell script helper.
+    expected_deps = set_expected_deps()
+    actual_deps = get_actual_deps()
+    if not actual_deps:
+        print 'List of deps is empty.'
+        exit_code = 14
+    else:
+        check_deps(expected_deps, actual_deps)
+
+    sys.exit(exit_code)
+
+if __name__ == '__main__':
+    main()

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -60,7 +60,8 @@ def get_allowed_deps():
                     'libpcre.so.1',
                 ])
     elif platform_system == 'aix':
-        # This is the standard list of deps for AIX 5.3.
+        # This is the standard list of deps for AIX 5.3. Some of the links
+        # for these libs moved in newer versions from '/usr/lib/' to '/lib/'.
         allowed_deps = [
             '/unix',
             'libbsd.a',

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -33,7 +33,18 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = [ 'bz2' ]
+disabled_module_list = [
+    '_bsddb',
+    '_curses',
+    '_curses_panel',
+    '_sqlite3',
+    '_tkinter',
+    'bz2',
+    'dbm',
+    'gdbm',
+    'readline',
+    'sunaudiodev',
+    ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.9/setup.py
+++ b/src/python/Python-2.7.9/setup.py
@@ -33,7 +33,18 @@ host_platform = get_platform()
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
 # This global variable is used to hold the list of modules to be disabled.
-disabled_module_list = [ 'bz2' ]
+disabled_module_list = [
+    '_bsddb',
+    '_curses',
+    '_curses_panel',
+    '_sqlite3',
+    '_tkinter',
+    'bz2',
+    'dbm',
+    'gdbm',
+    'readline',
+    'sunaudiodev',
+     ]
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if


### PR DESCRIPTION
Problem?
-------------
While working on #2647 a need arose to check the dependencies for the new Python binaries in `build/` so that our packages don't get contaminated with unwanted deps.

Solution?
------------
Use `ldd` or equivalents to build a list of deps for the build and compare it with a hardcoded minimal list for every supported OS.

**Drive-by fix**:
  * disable a few more modules to minimize dependencies for new builds.

How to check?
--------------------
Please review changes.
Run the tests.

reviewer: @adiroiban 