### PR TITLE
[#2647] Support for generic Linux distros.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -15,11 +15,11 @@
 UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev m4 texinfo"
 RHEL_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
 SLES_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
-# For the moment, we don't install anything on OS X, Solaris and AIX.
-# The build requires a C compiler, GNU make, m4, makeinfo (from texinfo,
-# optional) and the header files for OpenSSL and zlib. On platforms with
-# a choice of C compilers, you may choose one by setting/unsetting CC
-# and CXX in paver.sh.
+# For the moment, we don't install anything on OS X, Solaris, AIX and
+# unsupported Linux distros. The build requires a C compiler, GNU make, m4,
+# makeinfo (from texinfo, optional) and the header files for OpenSSL and zlib.
+# On platforms with a choice of C compilers, you may choose among them by
+# setting/unsetting CC and CXX in paver.sh.
 
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
@@ -145,7 +145,7 @@ install_dependencies() {
             install_command='sudo zypper --non-interactive install
                             --auto-agree-with-licenses'
         ;;
-        aix*|solaris*|osx*)
+        linux|aix*|solaris*|osx*)
             packages=""
             install_command=''
         ;;

--- a/paver.sh
+++ b/paver.sh
@@ -410,15 +410,15 @@ detect_os() {
                 exit 13
             fi
             OS="sles${sles_version}"
-        elif [ -f /etc/lsb-release ] ; then
+        elif [ $(command -v lsb_release) ]; then
             lsb_release_id=$(lsb_release -is)
+            lsb_release_nr=$(lsb_release -sr)
             if [ $lsb_release_id = Ubuntu ]; then
-                ubuntu_release=`lsb_release -sr`
-                if [ "$ubuntu_release" \< "10.04" ] ; then
-                    echo "Ubuntu version is too old: ${ubuntu_release}"
+                if [ "$lsb_release_nr" \< "10.04" ] ; then
+                    echo "Ubuntu version is too old: ${lsb_release_nr}"
                     exit 13
                 fi
-                case $ubuntu_release in
+                case $lsb_release_nr in
                     '10.04' | '10.10' | '11.04' | '11.10')
                         OS='ubuntu1004'
                     ;;
@@ -430,8 +430,6 @@ detect_os() {
                     ;;
                 esac
             fi
-        else
-            OS='linux'
         fi
 
     elif [ "${OS}" = "darwin" ] ; then


### PR DESCRIPTION
Problem?
----------
We added an x86 buildbot slave with Debian 7 to support generic Linux distros and we need `python-package` to work in this scenario.

Solution?
----------
Import an updated `paver.sh` from brink that refactored OS detection to support generic Linux distros.
Add support in `chevah_build` for generic Linux distros.

How to test?
--------------
Please review changes.
Run the tests.

reviewer: @adiroiban 