### PR TITLE
[#2700] Use updated buildbot with bz2file.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -7,7 +7,6 @@ Build script for Python binary distribution.
 RUN_PACKAGES = [
     'zope.interface==3.8.0',
     'twisted==12.1.0-chevah3',
-    'bz2file==0.98',
 
     # Buildbot is used for try scheduler
     'buildbot==0.8.11.pre.143.gac88f1b.c2',

--- a/pavement.py
+++ b/pavement.py
@@ -7,9 +7,10 @@ Build script for Python binary distribution.
 RUN_PACKAGES = [
     'zope.interface==3.8.0',
     'twisted==12.1.0-chevah3',
+    'bz2file==0.98',
 
     # Buildbot is used for try scheduler
-    'buildbot==0.8.8.c1',
+    'buildbot==0.8.11.pre.143.gac88f1b.c2',
 
     # Required for some unicode handling.
     'unidecode',


### PR DESCRIPTION
Problem?
-----------
With the new python-package, which has no `bz2` module, builtbot fails because it needs `bz2`.

Solution?
----------
Updated `pavement.py` to use a patched buildbot that uses `bz2file`.

How to test?
--------------
Please review changes.
Run tests.

reviewer: @adiroiban 