### PR TITLE
[#2713] Only remove installed packages.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -178,6 +178,10 @@ install_dependencies() {
 # installed by `install_dependencies` and leave the system clean.
 #
 remove_dependencies() {
+    local rpm_leaves
+    local zypper_options
+    local libzypp_version
+
     case $OS in
         ubuntu*)
             execute sudo apt-get --assume-yes --purge remove $INSTALLED_PACKAGES
@@ -191,12 +195,12 @@ remove_dependencies() {
                 # This partially works in RHEL 4 to 6 for automatically
                 # removing packages installed as dependencies (aka "leaves").
                 rhel_yum_autoremove() {
-                    RPM_LEAVES=$(package-cleanup --leaves --quiet 2>/dev/null \
+                    rpm_leaves=$(package-cleanup --leaves --quiet 2>/dev/null \
                         | egrep -v ^'Excluding|Finished')
-                    if [ -z "$RPM_LEAVES" ]; then
+                    if [ -z "$rpm_leaves" ]; then
                         (exit 0)
                     else
-                        execute sudo yum -y remove $RPM_LEAVES
+                        execute sudo yum -y remove $rpm_leaves
                         rhel_autoremove
                     fi
                 }
@@ -204,15 +208,15 @@ remove_dependencies() {
             fi
             ;;
         sles*)
-            ZYPPER_OPTIONS="--non-interactive"
+            zypper_options="--non-interactive"
             # zypper version 7.4 got support for automatically removing
             # unneeded packages, but only when removing installed packages.
             libzypp_version=$(rpm --query --queryformat '%{VERSION}' libzypp)
             IFS=. read -a libzypp_version_array <<< "$libzypp_version"
             if [ ${libzypp_version_array[0]} -gt 7 ]; then
-                ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
+                zypper_options="$zypper_options --clean-deps"
             fi
-            execute sudo zypper $ZYPPER_OPTIONS remove $INSTALLED_PACKAGES
+            execute sudo zypper $zypper_options remove $INSTALLED_PACKAGES
             ;;
     esac
 }

--- a/chevah_build
+++ b/chevah_build
@@ -12,9 +12,11 @@
 . ./functions.sh
 
 # List of OS packages required for building Python.
-UBUNTU_PACKAGES="gcc libssl-dev zlib1g-dev m4 texinfo"
-RHEL_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
-SLES_PACKAGES="gcc openssl-devel zlib-devel m4 texinfo"
+UBUNTU_PACKAGES="gcc make libssl-dev zlib1g-dev m4 texinfo"
+RHEL_PACKAGES="gcc make openssl-devel zlib-devel m4 texinfo"
+SLES_PACKAGES="gcc make libopenssl-devel zlib-devel m4 texinfo"
+# List of OS packages requested to be installed by this script.
+INSTALLED_PACKAGES=""
 # For the moment, we don't install anything on OS X, Solaris, AIX and
 # unsupported Linux distros. The build requires a C compiler, GNU make, m4,
 # makeinfo (from texinfo, optional) and the header files for OpenSSL and zlib.
@@ -130,32 +132,42 @@ install_dependencies() {
 
     packages='packages-not-defined'
     install_command='install-command-not-defined'
+    check_command='check-command-not-defined'
 
     case $OS in
         ubuntu*)
             packages=$UBUNTU_PACKAGES
             install_command='sudo apt-get --assume-yes install'
+            check_command='dpkg --status'
         ;;
         rhel*)
             packages=$RHEL_PACKAGES
             install_command='sudo yum -y install'
+            check_command='rpm --query'
         ;;
         sles*)
             packages=$SLES_PACKAGES
             install_command='sudo zypper --non-interactive install
                             --auto-agree-with-licenses'
+            check_command='rpm --query'
         ;;
         linux|aix*|solaris*|osx*)
             packages=""
             install_command=''
+            check_command=''
         ;;
     esac
 
     # We install one package after another since some package managers
     # (I am looking at you yum) will exit with 0 exit code if at least
     # one package was successfully installed.
+    echo "Installing required packages..."
     for package in $packages ; do
-        execute $install_command $package
+    $check_command $package
+    if [ $? -ne 0 ]; then
+            execute $install_command $package \
+                && INSTALLED_PACKAGES="$INSTALLED_PACKAGES $package"
+        fi
     done
 
 }
@@ -168,11 +180,11 @@ install_dependencies() {
 remove_dependencies() {
     case $OS in
         ubuntu*)
-            execute sudo apt-get --assume-yes --purge remove $UBUNTU_PACKAGES
+            execute sudo apt-get --assume-yes --purge remove $INSTALLED_PACKAGES
             execute sudo apt-get --assume-yes --purge autoremove
             ;;
         rhel*)
-            execute sudo yum -y remove $RHEL_PACKAGES
+            execute sudo yum -y remove $INSTALLED_PACKAGES
             if [ $OS \> 'rhel6' ]; then
                 execute sudo yum -y autoremove
             else
@@ -184,7 +196,7 @@ remove_dependencies() {
                     if [ -z "$RPM_LEAVES" ]; then
                         (exit 0)
                     else
-                        execute sudo yum -y remove "$RPM_LEAVES"
+                        execute sudo yum -y remove $RPM_LEAVES
                         rhel_autoremove
                     fi
                 }
@@ -198,7 +210,7 @@ remove_dependencies() {
             if [ $(rpm -qv libzypp) \> 'libzypp-7.39' ]; then
                 ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
             fi
-            execute sudo zypper $ZYPPER_OPTIONS remove $SLES_PACKAGES
+            execute sudo zypper $ZYPPER_OPTIONS remove $INSTALLED_PACKAGES
             ;;
     esac
 }

--- a/chevah_build
+++ b/chevah_build
@@ -189,7 +189,8 @@ remove_dependencies() {
             ;;
         rhel*)
             execute sudo yum -y remove $INSTALLED_PACKAGES
-            if [ $OS \> 'rhel6' ]; then
+            # RHEL7's yum learned how to auto-remove installed dependencies.
+            if [ ${OS##rhel} -ge 7 ]; then
                 execute sudo yum -y autoremove
             else
                 # This partially works in RHEL 4 to 6 for automatically

--- a/chevah_build
+++ b/chevah_build
@@ -207,7 +207,9 @@ remove_dependencies() {
             ZYPPER_OPTIONS="--non-interactive"
             # zypper version 7.4 got support for automatically removing
             # unneeded packages, but only when removing installed packages.
-            if [ $(rpm -qv libzypp) \> 'libzypp-7.39' ]; then
+            libzypp_version=$(rpm --query --queryformat '%{VERSION}' libzypp)
+            IFS=. read -a libzypp_version_array <<< "$libzypp_version"
+            if [ ${libzypp_version_array[0]} -gt 7 ]; then
                 ZYPPER_OPTIONS="$ZYPPER_OPTIONS --clean-deps"
             fi
             execute sudo zypper $ZYPPER_OPTIONS remove $INSTALLED_PACKAGES


### PR DESCRIPTION
Problem?
-----------
There are currently two issues with the package management in the `python-package` repo:

 1. We don't install `make` although it is required. And that's because we don't want to remove it at the end of the build as we need it on our build slaves for the other tests.

 2. We remove all managed packages, although some could have been installed before-hand. Eg. we uninstall `gcc` even if it was installed before the build. This is very annoying for the unsuspecting user…

Solution?
-----------
Use a new variable to keep count of the packages installed during build and only remove those.

**Drive-by fixes**:
  * get rid of string comparisons for version checks
  * style-guide fixes in `remove_dependencies()`.

How to check?
-----------------
Please review changes.
Run the test.

reviewer: @adiroiban 