### PR TITLE
[#2700] Use updated buildbot without bz2.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -9,7 +9,7 @@ RUN_PACKAGES = [
     'twisted==12.1.0-chevah3',
 
     # Buildbot is used for try scheduler
-    'buildbot==0.8.8.c1',
+    'buildbot==0.8.11.pre.143.gac88f1b.c2',
 
     # Required for some unicode handling.
     'unidecode',


### PR DESCRIPTION
Problem?
-----------
With the new python-package, which has no `bz2` module, builtbot fails because it needs `bz2`.

Solution?
----------
Updated `pavement.py` to use a patched buildbot that doesn't need `bz2`.

How to test?
--------------
Please review changes.
Run tests.

reviewer: @adiroiban