### PR TITLE
[#2728] Improved console messages.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -16,7 +16,7 @@ UBUNTU_PACKAGES="gcc make libssl-dev zlib1g-dev m4 texinfo"
 RHEL_PACKAGES="gcc make openssl-devel zlib-devel m4 texinfo"
 SLES_PACKAGES="gcc make libopenssl-devel zlib-devel m4 texinfo"
 # List of OS packages requested to be installed by this script.
-INSTALLED_PACKAGES=""
+INSTALLED_PACKAGES=''
 # For the moment, we don't install anything on OS X, Solaris, AIX and
 # unsupported Linux distros. The build requires a C compiler, GNU make, m4,
 # makeinfo (from texinfo, optional) and the header files for OpenSSL and zlib.
@@ -151,8 +151,7 @@ install_dependencies() {
         ;;
         sles*)
             packages=$SLES_PACKAGES
-            install_command='sudo zypper --non-interactive install
-                            --auto-agree-with-licenses'
+            install_command='sudo zypper --non-interactive install -l'
             check_command='rpm --query'
         ;;
         linux|aix*|solaris*|osx*)
@@ -188,6 +187,10 @@ remove_dependencies() {
     local rpm_leaves
     local zypper_options
     local libzypp_version
+
+    if [ -n "$INSTALLED_PACKAGES" ]; then
+        echo "Uninstalling the following packages: $INSTALLED_PACKAGES"
+    fi
 
     case $OS in
         ubuntu*)

--- a/chevah_build
+++ b/chevah_build
@@ -166,10 +166,12 @@ install_dependencies() {
     # (I am looking at you yum) will exit with 0 exit code if at least
     # one package was successfully installed.
     if [ -n "$packages" ]; then
-        echo "Installing required packages using sudo..."
+        echo "Checking for packages to be installed..."
         for package in $packages ; do
+            echo "Checking if $package is installed..."
             $check_command $package
             if [ $? -ne 0 ]; then
+                echo "Installing $package using ${install_command}..."
                 execute $install_command $package \
                     && INSTALLED_PACKAGES="$INSTALLED_PACKAGES $package"
             fi

--- a/chevah_build
+++ b/chevah_build
@@ -230,7 +230,10 @@ remove_dependencies() {
 
 help_text_clean="Clean the build."
 command_clean() {
-    rm -rf ${BUILD_FOLDER}
+    if [ -e ${BUILD_FOLDER} ]; then
+        echo 'Previous build sub-directory found. Removing...'
+        rm -rf ${BUILD_FOLDER}
+    fi
 }
 
 help_text_build="Create the Python binaries for current OS."

--- a/chevah_build
+++ b/chevah_build
@@ -156,7 +156,7 @@ install_dependencies() {
             check_command='rpm --query'
         ;;
         linux|aix*|solaris*|osx*)
-            packages=""
+            packages=''
             install_command=''
             check_command=''
         ;;
@@ -165,15 +165,16 @@ install_dependencies() {
     # We install one package after another since some package managers
     # (I am looking at you yum) will exit with 0 exit code if at least
     # one package was successfully installed.
-    echo "Installing required packages..."
-    for package in $packages ; do
-    $check_command $package
-    if [ $? -ne 0 ]; then
-            execute $install_command $package \
-                && INSTALLED_PACKAGES="$INSTALLED_PACKAGES $package"
-        fi
-    done
-
+    if [ -n "$packages" ]; then
+        echo "Installing required packages using sudo..."
+        for package in $packages ; do
+            $check_command $package
+            if [ $? -ne 0 ]; then
+                execute $install_command $package \
+                    && INSTALLED_PACKAGES="$INSTALLED_PACKAGES $package"
+            fi
+        done
+    fi
 }
 
 


### PR DESCRIPTION
Problem?
-----------
In AIX, Solaris, HP-UX and generic Linux we don't install any packages, but we still output this:
```
$ ./chevah_build build
Installing required packages...
```
Which may be followed by a long wait for removing the `build` sub-directory if there is one, without any console message. Which has the potential to freak any admin running this as a user with unrestricted `sudo` powers.

Solution?
------------
Only inform the user of installing packages when actually installing packages. Do it a slightly more detailed way showing what is going to be installed and how. Also inform of packages to be uninstalled.

**Drive-by fix**:
  * inform the user when removing previous build sub-directory. Sometimes this takes some time and there is no feedback for the user, eg. in our AIX WPARs.

How to check?
-----------------
Please review changes.
Run `./chevah_build build` on platforms when there are no packages to be installed, eg. AIX and generic Linux and also on platforms where there is something to install, eg. RHEL4 and Ubuntu 12.04
Run the tests.

reviewer: @adiroiban 