### PR TITLE
[#2755] Solaris 11 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -191,7 +191,7 @@ install_dependencies() {
 
 
 #
-# This function should do the best to remove the packages previously
+# This function should do its best to remove the packages previously
 # installed by `install_dependencies` and leave the system clean.
 #
 remove_dependencies() {
@@ -201,6 +201,8 @@ remove_dependencies() {
 
     if [ -n "$INSTALLED_PACKAGES" ]; then
         echo "Uninstalling the following packages: $INSTALLED_PACKAGES"
+    else
+        return
     fi
 
     case $OS in

--- a/chevah_build
+++ b/chevah_build
@@ -78,10 +78,11 @@ export MAKE=make
 
 case $OS in
     aix*)
-        # By default, we use IBM's XL C compiler. Comment these two for GCC.
-        # Beware that GCC 4.2 from IBM's RPMs will fail with GMP and Python!
-        CC="xlc_r"
-        CXX="xlC_r"
+        # By default, we use IBM's XL C compiler. Remove or comment out the
+        # CC and CXX lines to use GCC. However, beware that GCC 4.2 from
+        # IBM's RPMs will fail with GMP and Python!
+        export CC="xlc_r"
+        export CXX="xlC_r"
         export MAKE=gmake
         export PATH=/usr/vac/bin:$PATH
         export CFLAGS="-O2"
@@ -105,7 +106,7 @@ case $OS in
         fi
     ;;
     solaris*)
-       if [ "$OS" = "solaris10" ]; then
+        if [ "$OS" = "solaris10" ]; then
             # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
             # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
             PYTHON_BUILD_VERSION=2.7.8

--- a/chevah_build
+++ b/chevah_build
@@ -105,20 +105,20 @@ case $OS in
         fi
     ;;
     solaris*)
-        # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
-        # 2.7.9 do not support it. More at https://bugs.python.org/issue20981.
-        if [ "$OS" = "solaris10" ]; then
+       if [ "$OS" = "solaris10" ]; then
+            # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
+            # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
             PYTHON_BUILD_VERSION=2.7.8
+            # These are the default-included GNU make and makeinfo.
+            export MAKE=/usr/sfw/bin/gmake
+            export MAKEINFO=/usr/sfw/bin/makeinfo
+            # We favour the BSD-flavoured "install" over the default one.
+            # "ar", "nm" and "ld" are included by default in the same path.
+            export PATH=/usr/ccs/bin/:$PATH
         fi
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
         export CC="cc"
         export CXX="CC"
-        # This is the default-included GNU make and its counterpart: makeinfo.
-        export MAKE=/usr/sfw/bin/gmake
-        export MAKEINFO=/usr/sfw/bin/makeinfo
-        # We favour the BSD-flavoured "install" over the default one.
-        # "ar", "nm" and "ld" are included by default in the same path.
-        export PATH=/usr/ccs/bin/:$PATH
         # GCC is not in the usual PATH, we add the path to it if we want it.
         if [ "${CC}" = "gcc" ]; then
             export PATH="$PATH:/usr/sfw/bin/"

--- a/chevah_build
+++ b/chevah_build
@@ -107,7 +107,7 @@ case $OS in
     ;;
     solaris*)
         if [ "$OS" = "solaris10" ]; then
-            # Solaris 10 has OpenSSL 0.9.7 and Python 2.7 versions starting with
+            # Solaris 10 has OpenSSL 0.9.7, but Python 2 versions starting with
             # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
             PYTHON_BUILD_VERSION=2.7.8
             # These are the default-included GNU make and makeinfo.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -83,31 +83,46 @@ def get_allowed_deps():
                 'libthread.a',
             ])
     elif platform_system == 'sunos':
-        # This is the standard list of deps for a Solaris 10 build.
-        # For now, we include the major versions for Solaris libs.
+        # This is the common list of deps for Solaris 10 & 11 builds.
         allowed_deps = [
-            'libaio.so.1',
             'libc.so.1',
-            'libcrypt_i.so.1',
-            'libcrypto.so.0.9.7',
-            'libcrypto_extra.so.0.9.7',
             'libdl.so.1',
-            'libdoor.so.1',
-            'libgen.so.1',
             'libintl.so.1',
             'libm.so.2',
             'libmd.so.1',
             'libmp.so.2',
             'libnsl.so.1',
-            'librt.so.1',
-            'libscf.so.1',
             'libsocket.so.1',
             'libsqlite3.so.0',
-            'libssl.so.0.9.7',
-            'libssl_extra.so.0.9.7',
-            'libuutil.so.1',
             'libz.so.1',
             ]
+        # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
+        solaris_version = platform.release().split('.')[1]
+        if solaris_version == '10':
+            # Specific deps to add for Solaris 10.
+            allowed_deps.extend([
+                'libaio.so.1',
+                'libcrypt_i.so.1',
+                'libcrypto.so.0.9.7',
+                'libcrypto_extra.so.0.9.7',
+                'libdoor.so.1',
+                'libgen.so.1',
+                'librt.so.1',
+                'libscf.so.1',
+                'libssl.so.0.9.7',
+                'libssl_extra.so.0.9.7',
+                'libuutil.so.1',
+                ])
+        elif solaris_version == '11':
+            # Specific deps to add for Solaris 11.
+            allowed_deps.extend([
+                'libcrypt.so.1',
+                'libcrypto.so.1.0.0',
+                'libcryptoutil.so.1',
+                'libelf.so.1',
+                'libsoftcrypto.so.1',
+                'libssl.so.1.0.0',
+                ])
     elif platform_system == 'darwin':
         # This is the minimum list of deps for OS X.
         allowed_deps = [


### PR DESCRIPTION
Problem?
-----------
Building and testing `python-package` has some minor issues in Solaris 11.

Solution?
----------
Patch `python-package` to build and pass tests in Solaris 11.

Minor drive-by fixes:
  * only attempt to uninstall packages if there are packages to uninstall (this is why the rhel4 builds failed if all necessary packages were already installed)
  * better comments in the AIX section of `chevah_build`.

How to test?
--------------
Please review changes.
Run `./chevah_build build && ./chevah_build test` in Solaris 11.
Run the tests on the existing build slaves.

reviewer: @adiroiban 