### PR TITLE
[#2823] Fix sqlite-related build issues in Solaris 10u10 for Sparc.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -106,6 +106,16 @@ case $OS in
         fi
     ;;
     solaris*)
+        # By default, we use Sun's Studio compiler. Comment these two for GCC.
+        export CC="cc"
+        export CXX="CC"
+        # GCC is not in the usual PATH, we add the path to it if we want it.
+        if [ "${CC}" = "gcc" ]; then
+            export PATH="$PATH:/usr/sfw/bin/"
+        fi
+        if [ "${ARCH%64}" != "$ARCH" ]; then
+            export CFLAGS="-m64"
+        fi
         if [ "$OS" = "solaris10" ]; then
             # Solaris 10 has OpenSSL 0.9.7, but Python 2 versions starting with
             # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
@@ -116,20 +126,12 @@ case $OS in
             # We favour the BSD-flavoured "install" over the default one.
             # "ar", "nm" and "ld" are included by default in the same path.
             export PATH=/usr/ccs/bin/:$PATH
-        fi
-        # By default, we use Sun's Studio compiler. Comment these two for GCC.
-        export CC="cc"
-        export CXX="CC"
-        # GCC is not in the usual PATH, we add the path to it if we want it.
-        if [ "${CC}" = "gcc" ]; then
-            export PATH="$PATH:/usr/sfw/bin/"
-        fi
-        # And this is where the GNU libs are in Solaris 10, including OpenSSL.
-        if [ "${ARCH%64}" = "$ARCH" ]; then
-            export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
-        else
-            export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
-            export CFLAGS="-m64"
+            # And this is where the GNU libs are in Solaris 10, including OpenSSL.
+            if [ "${ARCH%64}" = "$ARCH" ]; then
+                export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
+            else
+                export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
+            fi
         fi
     ;;
     hpux*)

--- a/chevah_build
+++ b/chevah_build
@@ -377,7 +377,7 @@ initialize_python_module(){
                 mkdir -p Modules
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
                 if [ "$OS" = "solaris10" ]; then
-                    # This is needed for pyOpenSSL.in Solaris 10
+                    # Needed to build pyOpenSSL in Solaris 10.
                     if [ "${ARCH%64}" = "$ARCH" ]; then
                         execute $PYTHON_BIN setup.py build_ext \
                             -I/usr/sfw/include -L/usr/sfw/lib

--- a/chevah_build
+++ b/chevah_build
@@ -376,14 +376,16 @@ initialize_python_module(){
                 # Copy special link steps in local folder.
                 mkdir -p Modules
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
-                # This is needed for pyOpenSSL.
-                if [ "${ARCH%64}" = "$ARCH" ]; then
-                    execute $PYTHON_BIN setup.py build_ext -I/usr/sfw/include \
-                        -L/usr/sfw/lib
-                else
-                    execute $PYTHON_BIN setup.py build_ext -I/usr/sfw/include \
-                        -L/usr/sfw/lib/64
-                fi
+                if [ "$OS" = "solaris10" ]; then
+                    # This is needed for pyOpenSSL.in Solaris 10
+                    if [ "${ARCH%64}" = "$ARCH" ]; then
+                        execute $PYTHON_BIN setup.py build_ext \
+                            -I/usr/sfw/include -L/usr/sfw/lib
+                    else
+                        execute $PYTHON_BIN setup.py build_ext \
+                            -I/usr/sfw/include -L/usr/sfw/lib/64
+                   fi
+               fi
             ;;
         esac
     execute popd

--- a/chevah_build
+++ b/chevah_build
@@ -118,7 +118,7 @@ case $OS in
             export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
         else
             export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
-            export CFLAGS="-m64"
+            export CFLAGS="-m64 -xcode=abs64"
         fi
         if [ "$OS" = "solaris10" ]; then
             # Solaris 10 has OpenSSL 0.9.7, but Python 2 versions starting with
@@ -384,8 +384,8 @@ initialize_python_module(){
                     else
                         execute $PYTHON_BIN setup.py build_ext \
                             -I/usr/sfw/include -L/usr/sfw/lib/64
-                   fi
-               fi
+                    fi
+                fi
             ;;
         esac
     execute popd

--- a/chevah_build
+++ b/chevah_build
@@ -130,6 +130,12 @@ case $OS in
             # We favour the BSD-flavoured "install" over the default one.
             # "ar", "nm" and "ld" are included by default in the same path.
             export PATH=/usr/ccs/bin/:$PATH
+            # sqlite3 lib location in all Solaris'es (incl. 10s10 for Sparc).
+            if [ "${ARCH%64}" = "$ARCH" ]; then
+                export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
+            else
+                export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
+            fi
         fi
     ;;
     hpux*)
@@ -377,13 +383,18 @@ initialize_python_module(){
                 mkdir -p Modules
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
                 if [ "$OS" = "solaris10" ]; then
-                    # Needed to build pyOpenSSL in Solaris 10.
+                    # Needed to build pyOpenSSL and pysqlite in Solaris 10.
+                    # Make sure the headers for OpenSSL and sqlite3 are present
+                    # in /usr/sfw/include (only one location allowed, it seems).
                     if [ "${ARCH%64}" = "$ARCH" ]; then
                         execute $PYTHON_BIN setup.py build_ext \
-                            -I/usr/sfw/include -L/usr/sfw/lib
+                            -I/usr/sfw/include \
+                            -L/usr/sfw/lib -L/usr/lib/mps
                     else
                         execute $PYTHON_BIN setup.py build_ext \
-                            -I/usr/sfw/include -L/usr/sfw/lib/64
+                            -I/usr/sfw/include \
+                            -L/usr/sfw/lib/64 -L/usr/lib/mps/64
+
                     fi
                 fi
             ;;

--- a/chevah_build
+++ b/chevah_build
@@ -109,11 +109,15 @@ case $OS in
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
         export CC="cc"
         export CXX="CC"
-        # GCC is not in the usual PATH, we add the path to it if we want it.
+        # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then
             export PATH="$PATH:/usr/sfw/bin/"
         fi
-        if [ "${ARCH%64}" != "$ARCH" ]; then
+        # And this is where the GNU libs are in Solaris 10, including OpenSSL.
+        if [ "${ARCH%64}" = "$ARCH" ]; then
+            export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
+        else
+            export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="-m64"
         fi
         if [ "$OS" = "solaris10" ]; then
@@ -126,12 +130,6 @@ case $OS in
             # We favour the BSD-flavoured "install" over the default one.
             # "ar", "nm" and "ld" are included by default in the same path.
             export PATH=/usr/ccs/bin/:$PATH
-            # And this is where the GNU libs are in Solaris 10, including OpenSSL.
-            if [ "${ARCH%64}" = "$ARCH" ]; then
-                export LDFLAGS="-L/usr/sfw/lib -R/usr/sfw/lib"
-            else
-                export LDFLAGS="-m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
-            fi
         fi
     ;;
     hpux*)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -93,7 +93,7 @@ def get_allowed_deps():
             'libmp.so.2',
             'libnsl.so.1',
             'libsocket.so.1',
-            'libsqlite3.so.0',
+            'libsqlite3.so',
             'libz.so.1',
             ]
         # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
@@ -111,6 +111,7 @@ def get_allowed_deps():
                 'libscf.so.1',
                 'libssl.so.0.9.7',
                 'libssl_extra.so.0.9.7',
+                'libthread.so.1',
                 'libuutil.so.1',
                 ])
         elif solaris_version == '11':

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -230,8 +230,8 @@ def main():
         exit_code = 5
 
     try:
-        import pysqlite2
-        pysqlite2
+        from pysqlite2 import test
+        test.test()
     except:
         sys.stderr.write('"pysqlite2" missing.\n')
         exit_code = 6

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -81,7 +81,7 @@ def get_allowed_deps():
         if aix_version >= 7:
             allowed_deps.extend([
                 'libthread.a',
-            ])
+                ])
     elif platform_system == 'sunos':
         # This is the common list of deps for Solaris 10 & 11 builds.
         allowed_deps = [
@@ -96,6 +96,11 @@ def get_allowed_deps():
             'libsqlite3.so',
             'libz.so.1',
             ]
+        if platform.processor() == 'sparc':
+            allowed_deps.extend([
+                'libc_psr.so.1',
+                'libmd_psr.so.1',
+                ])
         # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
         solaris_version = platform.release().split('.')[1]
         if solaris_version == '10':

--- a/src/python/Python-2.7.8/Lib/distutils/command/build_ext.py
+++ b/src/python/Python-2.7.8/Lib/distutils/command/build_ext.py
@@ -459,6 +459,9 @@ class build_ext (Command):
         if not (self.force or newer_group(depends, ext_path, 'newer')):
             log.debug("skipping '%s' extension (up-to-date)", ext.name)
             return
+        elif ext.name.startswith('pysqlite'):
+            log.debug("skipping '%s' extension (chevah hack)", ext.name)
+            return
         else:
             log.info("building '%s' extension", ext.name)
 

--- a/src/python/Python-2.7.8/Lib/distutils/command/build_ext.py
+++ b/src/python/Python-2.7.8/Lib/distutils/command/build_ext.py
@@ -459,9 +459,6 @@ class build_ext (Command):
         if not (self.force or newer_group(depends, ext_path, 'newer')):
             log.debug("skipping '%s' extension (up-to-date)", ext.name)
             return
-        elif ext.name.startswith('pysqlite'):
-            log.debug("skipping '%s' extension (chevah hack)", ext.name)
-            return
         else:
             log.info("building '%s' extension", ext.name)
 


### PR DESCRIPTION
Problem?
-----------
On Solaris 10u10 Sparc edition, which doesn't include the sqlite3 includes and libs in `/usr`, the build fails when compiling `pysqlite`.

Solution
----------
Use sqlite3 lib from `/usr/lib/mcs`, common to Solaris 10u10, 10u11 and 11u2.

Drive-by fix:
  * in Solaris 10 for Sparc, building `_fastmath` in pyCrypto requires a special compilation flag.

How to test?
--------------
Please review changes.
Build the package in Solaris 10u10 for Sparc.

reviewer: @adiroiban 