### PR TITLE
[#2689] Readline support on selected platforms.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -31,6 +31,9 @@ def get_allowed_deps():
             'libz.so',
             'linux-gate.so',
             'linux-vdso.so',
+            'libncurses.so',
+            'libncursesw.so',
+            'libreadline.so',
             ]
         # Distro-specific deps to add. Now we may specify major versions too.
         linux_distro_name = platform.linux_distribution()[0]

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -131,6 +131,8 @@ def get_allowed_deps():
                 'libelf.so.1',
                 'libsoftcrypto.so.1',
                 'libssl.so.1.0.0',
+                'libreadline.so.5',
+                'libncurses.so.5',
                 ])
     elif platform_system == 'darwin':
         # This is the minimum list of deps for OS X.

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -46,7 +46,7 @@ disabled_module_list = [
     ]
 
 # Compile readline module only on platforms whitelisted below.
-if host_platform not in ('linux2'):
+if host_platform not in ('linux2', 'sunos5'):
     disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -42,9 +42,12 @@ disabled_module_list = [
     'bz2',
     'dbm',
     'gdbm',
-    'readline',
     'sunaudiodev',
     ]
+
+# Compile readline module only on platforms whitelisted below.
+if host_platform not in ('linux2'):
+    disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.9/setup.py
+++ b/src/python/Python-2.7.9/setup.py
@@ -42,9 +42,12 @@ disabled_module_list = [
     'bz2',
     'dbm',
     'gdbm',
-    'readline',
     'sunaudiodev',
      ]
+
+# Compile readline module only on platforms whitelisted below.
+if host_platform not in ('linux2'):
+    disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if

--- a/src/python/Python-2.7.9/setup.py
+++ b/src/python/Python-2.7.9/setup.py
@@ -46,7 +46,7 @@ disabled_module_list = [
      ]
 
 # Compile readline module only on platforms whitelisted below.
-if host_platform not in ('linux2'):
+if host_platform not in ('linux2', 'sunos5'):
     disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):


### PR DESCRIPTION
Problem?
-----------
We want  to have the `readline` module compiled on Linux and other platforms that have the `readline` libs installed by default.

Solution?
----------
Enable `readline` on selected white-listed platforms such as Linux and Solaris.

How to check?
-----------------
Please check the changes.
Run the `python-package` tests on all supported platforms.

reviewer @adiroiban 