### PR TITLE
[#2920] Fix Solaris 11 builds.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -145,7 +145,7 @@ case $OS in
     ;;
 esac
 
-# Compiler-dependet flags. At this moment we should know what compiler is used.
+# Compiler-dependent flags. At this moment we should know what compiler is used.
 if [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
     # Use PIC (Position Independent Code) with GCC on 64-bit arches.
     export CFLAGS="${CFLAGS} -fPIC"

--- a/chevah_build
+++ b/chevah_build
@@ -67,10 +67,6 @@ export CC='gcc'
 # when not using gcc, and thus silence the associated configure warning.
 # However, we set $CPPFLAGS later for linking to statically-compiled libs.
 export CXX='g++'
-# Use PIC (Position Independent Code) with GCC on 64-bit arches.
-if [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
-    export CFLAGS="${CFLAGS} -fPIC"
-fi
 
 LOCAL_PYTHON_BINARY_DIST="$PYTHON_VERSION-$OS-$ARCH"
 INSTALL_FOLDER=$PWD/${BUILD_FOLDER}/$LOCAL_PYTHON_BINARY_DIST
@@ -112,6 +108,7 @@ case $OS in
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
         export CC="cc"
         export CXX="CC"
+        export MAKE="gmake"
         # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then
             export PATH="$PATH:/usr/sfw/bin/"
@@ -152,6 +149,10 @@ case $OS in
     ;;
 esac
 
+# Use PIC (Position Independent Code) with GCC on 64-bit arches.
+if [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
+    export CFLAGS="${CFLAGS} -fPIC"
+fi
 
 #
 # Install OS package required to build Python.
@@ -294,7 +295,7 @@ command_build() {
     # support without linking to the GPL'ed readline.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
-        ubuntu*|rhel*|sles*|linux|solaris*)
+        ubuntu*|rhel*|sles*|linux)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \
                 $INSTALL_FOLDER/include/

--- a/chevah_build
+++ b/chevah_build
@@ -113,7 +113,7 @@ case $OS in
         if [ "${CC}" = "gcc" ]; then
             export PATH="$PATH:/usr/sfw/bin/"
         fi
-        # And this is where the GNU libs are in Solaris 10, including OpenSSL.
+        # The location for GNU libs in Solaris, including OpenSSL in Solaris 10.
         if [ "${ARCH%64}" = "$ARCH" ]; then
             export LDFLAGS="$LDFLAGS -L/usr/sfw/lib -R/usr/sfw/lib"
         else
@@ -145,15 +145,16 @@ case $OS in
     ;;
 esac
 
-# Use PIC (Position Independent Code) with GCC on 64-bit arches.
+# Compiler-dependet flags. At this moment we should know what compiler is used.
 if [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
+    # Use PIC (Position Independent Code) with GCC on 64-bit arches.
     export CFLAGS="${CFLAGS} -fPIC"
 elif [ "${OS%solaris*}" = "" ]; then
     if [ ${ARCH} = "sparc64" ]; then
-        # Required for compiling GMP.
+        # Required for compiling GMP on Solaris for SPARC with Sun Studio.
         export CFLAGS="$CFLAGS -xcode=abs64"
     elif [ ${ARCH} = "x64" ]; then
-        # Required for libedit, which has a simpler configure setup.
+        # Required for linking to libedit, which has a simpler configure setup.
         export CFLAGS="$CFLAGS -xcode=pic32"
     fi
 fi

--- a/chevah_build
+++ b/chevah_build
@@ -294,7 +294,7 @@ command_build() {
     # support without linking to the GPL'ed readline.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
-        ubuntu*|rhel*|sles*|linux)
+        ubuntu*|rhel*|sles*|linux|solaris*)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \
                 $INSTALL_FOLDER/include/
@@ -414,11 +414,9 @@ initialize_python_module(){
                     # Make sure the headers for OpenSSL and sqlite3 are present
                     # in /usr/sfw/include (only one location allowed, it seems).
                     if [ "${ARCH%64}" = "$ARCH" ]; then
-                        extra_args=\
-                            "$extra_args -L/usr/sfw/lib -L/usr/lib/mps"
+                        extra_args="$extra_args -L/usr/sfw/lib -L/usr/lib/mps"
                     else
-                        extra_args=\
-                            "$extra_args -L/usr/sfw/lib/64 -L/usr/lib/mps/64"
+                        extra_args="$extra_args -L/usr/sfw/lib/64 -L/usr/lib/mps/64"
                     fi
                 fi
                 execute $PYTHON_BIN setup.py build_ext $extra_args

--- a/chevah_build
+++ b/chevah_build
@@ -119,10 +119,6 @@ case $OS in
         else
             export LDFLAGS="$LDFLAGS -m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="$CFLAGS -m64"
-            if [ ${ARCH} = "sparc64" ]; then
-                # Required for compiling GMP.
-                export CFLAGS="$CFLAGS -xcode=abs64"
-            fi
         fi
         if [ "$OS" = "solaris10" ]; then
             # Solaris 10 has OpenSSL 0.9.7, but Python 2 versions starting with
@@ -152,6 +148,14 @@ esac
 # Use PIC (Position Independent Code) with GCC on 64-bit arches.
 if [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
     export CFLAGS="${CFLAGS} -fPIC"
+elif [ "${OS%solaris*}" = "" ]; then
+    if [ ${ARCH} = "sparc64" ]; then
+        # Required for compiling GMP.
+        export CFLAGS="$CFLAGS -xcode=abs64"
+    elif [ ${ARCH} = "x64" ]; then
+        # Required for libedit, which has a simpler configure setup.
+        export CFLAGS="$CFLAGS -xcode=pic32"
+    fi
 fi
 
 #
@@ -295,7 +299,7 @@ command_build() {
     # support without linking to the GPL'ed readline.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
-        ubuntu*|rhel*|sles*|linux)
+        ubuntu*|rhel*|sles*|linux|solaris*)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \
                 $INSTALL_FOLDER/include/

--- a/chevah_build
+++ b/chevah_build
@@ -402,27 +402,27 @@ initialize_python_module(){
                 # Copy special link steps in local folder.
                 mkdir -p Modules
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
-            ;;
+                ;;
             solaris*)
                 # Copy special link steps in local folder.
                 mkdir -p Modules
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
+                extra_args=""
                 if [ "$OS" = "solaris10" ]; then
+                    extra_args="$extra_args -I/usr/sfw/include"
                     # Needed to build pyOpenSSL and pysqlite in Solaris 10.
                     # Make sure the headers for OpenSSL and sqlite3 are present
                     # in /usr/sfw/include (only one location allowed, it seems).
                     if [ "${ARCH%64}" = "$ARCH" ]; then
-                        execute $PYTHON_BIN setup.py build_ext \
-                            -I/usr/sfw/include \
-                            -L/usr/sfw/lib -L/usr/lib/mps
+                        extra_args=\
+                            "$extra_args -L/usr/sfw/lib -L/usr/lib/mps"
                     else
-                        execute $PYTHON_BIN setup.py build_ext \
-                            -I/usr/sfw/include \
-                            -L/usr/sfw/lib/64 -L/usr/lib/mps/64
-
+                        extra_args=\
+                            "$extra_args -L/usr/sfw/lib/64 -L/usr/lib/mps/64"
                     fi
                 fi
-            ;;
+                execute $PYTHON_BIN setup.py build_ext $extra_args
+                ;;
         esac
     execute popd
 }

--- a/chevah_build
+++ b/chevah_build
@@ -121,7 +121,11 @@ case $OS in
             export LDFLAGS="$LDFLAGS -L/usr/sfw/lib -R/usr/sfw/lib"
         else
             export LDFLAGS="$LDFLAGS -m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
-            export CFLAGS="$CFLAGS -m64 -xcode=abs64"
+            export CFLAGS="$CFLAGS -m64"
+            if [ ${ARCH} = "sparc64" ]; then
+                # Required for compiling GMP.
+                export CFLAGS="$CFLAGS -xcode=abs64"
+            fi
         fi
         if [ "$OS" = "solaris10" ]; then
             # Solaris 10 has OpenSSL 0.9.7, but Python 2 versions starting with

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -111,7 +111,6 @@ def get_allowed_deps():
             'libmp.so.2',
             'libnsl.so.1',
             'libsocket.so.1',
-            'libsqlite3.so',
             'libz.so.1',
             ]
         if platform.processor() == 'sparc':
@@ -128,10 +127,12 @@ def get_allowed_deps():
                 'libcrypt_i.so.1',
                 'libcrypto.so.0.9.7',
                 'libcrypto_extra.so.0.9.7',
+                'libcurses.so.1',
                 'libdoor.so.1',
                 'libgen.so.1',
                 'librt.so.1',
                 'libscf.so.1',
+                'libsqlite3.so',
                 'libssl.so.0.9.7',
                 'libssl_extra.so.0.9.7',
                 'libthread.so.1',
@@ -144,7 +145,9 @@ def get_allowed_deps():
                 'libcrypto.so.1.0.0',
                 'libcryptoutil.so.1',
                 'libelf.so.1',
+                'libncurses.so.5',
                 'libsoftcrypto.so.1',
+                'libsqlite3.so.0',
                 'libssl.so.1.0.0',
                 ])
     elif platform_system == 'darwin':
@@ -307,10 +310,10 @@ def main():
             exit_code = 12
 
     # We compile the readline module using libedit only on selected platforms.
-    if platform_system == 'linux':
+    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
         try:
             import readline
-            readline.clear_history()
+            readline.get_history_length()
         except:
             sys.stderr.write('"readline" missing.\n')
             exit_code = 13

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -307,7 +307,7 @@ def main():
             exit_code = 12
 
     # We compile the readline module using libedit only on selected platforms.
-    if platform_system == 'linux':
+    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
         try:
             import readline
             readline.clear_history()

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -307,7 +307,7 @@ def main():
             exit_code = 12
 
     # We compile the readline module using libedit only on selected platforms.
-    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
+    if platform_system == 'linux':
         try:
             import readline
             readline.clear_history()

--- a/src/libedit/chevahbs
+++ b/src/libedit/chevahbs
@@ -11,7 +11,7 @@ chevahbs_configure() {
     # Support for Unicode (wide-char/UTF-8) is added with "--enable-widec".
     CONF_OPTS="--disable-shared --enable-static --enable-widec"
     execute mkdir m4
-    # RHEL 5 has an older autoconf, and we can't auto-reconfigure.
+    # RHEL 4 and 5 have an older autoconf, and we can't auto-reconfigure.
     case $OS in
         rhel4|rhel5)
             # This redirects the echo output to stderr.

--- a/src/libedit/chevahbs
+++ b/src/libedit/chevahbs
@@ -13,13 +13,13 @@ chevahbs_configure() {
     execute mkdir m4
     # RHEL 5 has an older autoconf, and we can't auto-reconfigure.
     case $OS in
-        rhel5)
+        rhel4|rhel5)
             # This redirects the echo output to stderr.
-            >&2 echo "This seems to be a RHEL 5 system, skipping autoreconf..."
-        ;;
+            >&2 echo "This seems to be a RHEL 4/5 system, skipping autoreconf!"
+            ;;
         *)
             execute autoreconf --install --force
-        ;;
+            ;;
     esac
     execute ./configure --prefix="" $CONF_OPTS
 }

--- a/src/libedit/libedit-20150325-3.1/configure.ac
+++ b/src/libedit/libedit-20150325-3.1/configure.ac
@@ -82,6 +82,9 @@ AC_CHECK_HEADERS([fcntl.h limits.h malloc.h stdlib.h string.h sys/ioctl.h sys/pa
 
 AC_CHECK_HEADER([termios.h], [], [AC_MSG_ERROR([termios.h is required!])],[])
 
+# Solaris 10 doesn't have it.
+AC_CHECK_HEADERS([err.h])
+
 ## include curses.h to prevent "Present But Cannot Be Compiled"
 AC_CHECK_HEADERS([term.h],,,
 [[#if HAVE_CURSES_H

--- a/src/libedit/libedit-20150325-3.1/examples/wtc1.c
+++ b/src/libedit/libedit-20150325-3.1/examples/wtc1.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <signal.h>
 #include <sys/wait.h>
-#include <err.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -12,6 +11,25 @@
 
 #include <histedit.h>
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+/* On Solaris 10, you can't simply include err.h */
+#ifdef HAVE_ERR_H
+#include <err.h>
+#else
+# include <errno.h>
+# include <string.h>
+# define err(exitcode, format, args...) \
+   errx(exitcode, format ": %s", ## args, strerror(errno))
+# define errx(exitcode, format, args...) \
+   { warnx(format, ## args); exit(exitcode); }
+# define warn(format, args...) \
+   warnx(format ": %s", ## args, strerror(errno))
+# define warnx(format, args...) \
+   fprintf(stderr, format "\n", ## args)
+#endif
 
 static int continuation;
 volatile sig_atomic_t gotsig;

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -46,7 +46,7 @@ disabled_module_list = [
     ]
 
 # Compile the readline module only on platforms whitelisted below.
-if host_platform not in ('linux2'):
+if host_platform not in ('linux2', 'sunos5' ):
     disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):

--- a/src/python/Python-2.7.8/setup.py
+++ b/src/python/Python-2.7.8/setup.py
@@ -46,7 +46,7 @@ disabled_module_list = [
     ]
 
 # Compile the readline module only on platforms whitelisted below.
-if host_platform not in ('linux2', 'sunos5' ):
+if host_platform not in ('linux2'):
     disabled_module_list.append('readline')
 
 def add_dir_to_list(dirlist, dir):

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -54,19 +54,18 @@ chevahbs_configure() {
                 --with-system-ffi \
                 "
             ;;
-        solaris*)
-            # In Solaris the default OpenSSL installation lives in /usr/sfw/.
+        solaris10)
+            # In Solaris 10, the default OpenSSL is installed in /usr/sfw/.
             # Both include options are needed to match both the native Sun
             # Studio compiler and GCC.
             if [ "${ARCH%64}" = "$ARCH" ]; then
                 echo "_ssl _ssl.c -I/usr/sfw/include" \
                     "-I/usr/sfw/include/openssl -L/usr/sfw/lib" \
-                    " -R/usr/sfw/lib -lssl -lcrypto" >> Modules/Setup.local
+                    "-R/usr/sfw/lib -lssl -lcrypto" >> Modules/Setup.local
             else
-                CONFIG_ARGS="${CONFIG_ARGS} CFLAGS=-m64 LDFLAGS=-m64"
                 echo "_ssl _ssl.c -I/usr/sfw/include" \
                     "-I/usr/sfw/include/openssl -L/usr/sfw/lib/64" \
-                    " -R/usr/sfw/lib/64 -lssl -lcrypto" >> Modules/Setup.local
+                    "-R/usr/sfw/lib/64 -lssl -lcrypto" >> Modules/Setup.local
             fi
             ;;
     esac


### PR DESCRIPTION
Problem?
-----------
While fixing an sqlite-related problem in Solaris 10 for SPARC, the Solaris 11 builds were inadvertently impaired by the changes.

Solution?
-----------
Fix the problem with the Solaris 11 builds.

**Drive-by fixes**:
  * only use the compiler flag `-xcode=abs64` on SPARC platforms, where it is relevant
  * improved compile flags setup in `chevah_build`
  * minor improvements for Solaris systems
  * `libedit` fix for platforms with no `err.h`, such as Solaris 10
  * integrate `libedit` for `readline` support on Solaris (less functional than in Linux and somewhat buggier).

How to check?
-----------------
Please review the changes.
Run the `python-package` tests.
Run the `server` tests on Solaris 11 with the new Python package in testing, as here: http://build.chevah.com/builders/server-solaris-11/builds/172

reviewer: @adiroiban 