### PR TITLE
[#2962] Raspbian support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build/
 dist/
 DEFAULT_VALUES
 build-*/
-cache/
+cache

--- a/chevah_build
+++ b/chevah_build
@@ -13,14 +13,14 @@
 
 # List of OS packages required for building Python.
 COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
-UBUNTU_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
+DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
 RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
 SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
 # List of OS packages requested to be installed by this script.
 INSTALLED_PACKAGES=''
 # For now, we don't install anything on OS X, Solaris, AIX, and
 # unsupported Linux distros. The build requires a C compiler, GNU make, m4,
-# the header files for OpenSSL and zlib, and optionally texinfo.
+# the header files for OpenSSL and zlib, and (optionally) texinfo.
 # To build libedit for the readline module, we need the headers of
 # a curses library, automake and libtool.
 # On platforms with a choice of C compilers, you may choose among the
@@ -169,8 +169,9 @@ install_dependencies() {
     check_command='check-command-not-defined'
 
     case $OS in
-        ubuntu*)
-            packages=$UBUNTU_PACKAGES
+        # Debian-derived distros are similar in this regard.
+        ubuntu*|raspbian*)
+            packages=$DEBIAN_PACKAGES
             install_command='sudo apt-get --assume-yes install'
             check_command='dpkg --status'
         ;;
@@ -184,7 +185,7 @@ install_dependencies() {
             install_command='sudo zypper --non-interactive install -l'
             check_command='rpm --query'
         ;;
-        linux|aix*|solaris*|osx*)
+        *)
             packages=''
             install_command=''
             check_command=''
@@ -226,7 +227,7 @@ remove_dependencies() {
     fi
 
     case $OS in
-        ubuntu*)
+        ubuntu*|raspbian*)
             execute sudo apt-get --assume-yes --purge remove $INSTALLED_PACKAGES
             execute sudo apt-get --assume-yes --purge autoremove
             ;;
@@ -300,7 +301,7 @@ command_build() {
     # support without linking to the GPL'ed readline.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
-        ubuntu*|rhel*|sles*|linux|solaris*)
+        ubuntu*|raspbian*|rhel*|sles*|linux|solaris*)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \
                 $INSTALL_FOLDER/include/

--- a/paver.sh
+++ b/paver.sh
@@ -427,8 +427,7 @@ detect_os() {
 
         if [ -f /etc/redhat-release ]; then
             # Avoid getting confused by Red Hat derivatives such as Fedora.
-            egrep 'Red\ Hat|CentOS|Scientific' /etc/redhat-release > /dev/null
-            if [ $? -eq 0 ]; then
+            if egrep -q 'Red\ Hat|CentOS|Scientific' /etc/redhat-release; then
                 os_version_raw=$(\
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
                 check_os_version "Red Hat Enterprise Linux" 4 \
@@ -458,16 +457,13 @@ detect_os() {
                     OS="ubuntu${os_version_chevah}"
                 fi
             fi
-            if [ -f /etc/os-release ]; then
-                # Check for Raspbian, which is a Debian unofficial derivative.
-                grep -i "raspbian" /etc/os-release > /dev/null
-                if [ $? -eq 0 ]; then
-                    check_os_version "Raspbian Linux" 7 \
-                        "$os_version_raw" os_version_chevah
-                    # For now, we only generate a Raspbian version 7.x package,
-                    # and we should use that in Raspbian version 8.x too.
-                    OS="raspbian7"
-                fi
+            # Check for Raspbian, which is a Debian unofficial derivative.
+            if grep --quiet raspbian /etc/os-release 2>/dev/null; then
+                check_os_version "Raspbian Linux" 7 \
+                    "$os_version_raw" os_version_chevah
+                # For now, we only generate a Raspbian version 7.x package,
+                # and we should use that in Raspbian version 8.x too.
+                OS="raspbian7"
             fi
         fi
 

--- a/paver.sh
+++ b/paver.sh
@@ -458,6 +458,17 @@ detect_os() {
                     OS="ubuntu${os_version_chevah}"
                 fi
             fi
+            if [ -f /etc/os-release ]; then
+                # Check for Raspbian, which is a Debian unofficial derivative.
+                grep -i "raspbian" /etc/os-release > /dev/null
+                if [ $? -eq 0 ]; then
+                    check_os_version "Raspbian Linux" 7 \
+                        "$os_version_raw" os_version_chevah
+                    # For now, we only generate a Raspbian version 7.x package,
+                    # and we should use that in Raspbian version 8.x too.
+                    OS="raspbian7"
+                fi
+            fi
         fi
 
     elif [ "${OS}" = "darwin" ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -443,6 +443,17 @@ detect_os() {
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
             fi
+        elif [ -f /etc/rpi-issue ]; then
+            # Raspbian is a special case, a Debian unofficial derivative.
+            if egrep -q ^'NAME="Raspbian GNU/Linux' /etc/os-release; then
+                os_version_raw=$(\
+                    grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
+                check_os_version "Raspbian GNU/Linux" 7 \
+                    "$os_version_raw" os_version_chevah
+                # For now, we only generate a Raspbian version 7.x package,
+                # and we should use that in newer Raspbian versions too.
+                OS="raspbian7"
+            fi
         elif [ $(command -v lsb_release) ]; then
             lsb_release_id=$(lsb_release -is)
             os_version_raw=$(lsb_release -rs)
@@ -456,14 +467,6 @@ detect_os() {
                     $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
                     OS="ubuntu${os_version_chevah}"
                 fi
-            fi
-            # Check for Raspbian, which is a Debian unofficial derivative.
-            if grep --quiet raspbian /etc/os-release 2>/dev/null; then
-                check_os_version "Raspbian Linux" 7 \
-                    "$os_version_raw" os_version_chevah
-                # For now, we only generate a Raspbian version 7.x package,
-                # and we should use that in Raspbian version 8.x too.
-                OS="raspbian7"
             fi
         fi
 

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -72,16 +72,13 @@ def get_allowed_deps():
                 'libtinfo.so.5',
                 ])
         else:
-            try:
-                os_release_dump = open("/etc/os-release")
-            except:
-                sys.stderr.write('Linux distro with no os-release in /etc?')
-            else:
-                if 'raspbian' in os_release_dump.read():
-                    allowed_deps.extend([
-                        'libcofi_rpi.so',
-                        'libgcc_s.so.1',
-                        ])
+            # Raspbian is a special case... If this file exists, we assume the
+            # distro passes the more stringent checks in paver.sh during build.
+            if os.path.isfile("/etc/rpi-issue"):
+                allowed_deps.extend([
+                    'libcofi_rpi.so',
+                    'libgcc_s.so.1',
+                    ])
             # For generic Linux distros, such as Debian.
             allowed_deps.extend([
                 'libncurses.so.5',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -72,6 +72,16 @@ def get_allowed_deps():
                 'libtinfo.so.5',
                 ])
         else:
+            try:
+                os_release_dump = open("/etc/os-release")
+            except:
+                sys.stderr.write('Linux distro with no os-release in /etc?')
+            else:
+                if 'raspbian' in os_release_dump.read():
+                    allowed_deps.extend([
+                        'libcofi_rpi.so',
+                        'libgcc_s.so.1',
+                        ])
             # For generic Linux distros, such as Debian.
             allowed_deps.extend([
                 'libncurses.so.5',

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -20,7 +20,7 @@ chevahbs_configure() {
             CONF_OPTS="$CONF_OPTS --with-pic"
         fi
     elif [ x${ARCH} == x"armv7l"  ]; then
-        CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf"
+        CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf --with-pic"
     fi
     execute ./configure --prefix="" $CONF_OPTS
 }

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -19,9 +19,12 @@ chevahbs_configure() {
             # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
             CONF_OPTS="$CONF_OPTS --with-pic"
         fi
-    elif [ x${ARCH} == x"armv7l"  ]; then
-        CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf --with-pic"
     fi
+    case $OS in
+        raspbian*)
+            CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf --with-pic"
+        ;;
+    esac
     execute ./configure --prefix="" $CONF_OPTS
 }
 

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -19,6 +19,8 @@ chevahbs_configure() {
             # https://www.gentoo.org/proj/en/base/amd64/howtos/index.xml?part=1&chap=3#doc_chap7
             CONF_OPTS="$CONF_OPTS --with-pic"
         fi
+    elif [ x${ARCH} == x"armv7l"  ]; then
+        CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf"
     fi
     execute ./configure --prefix="" $CONF_OPTS
 }


### PR DESCRIPTION
Problem
----------
Building `python-package` failed on our RPi because of `gmp` issues.

Solution
----------
Fix the `gmp` issue and other problems for building in Raspbian 7.x. 
Please notice that the focus changed from supporting the arch (armv7l) to supporting Raspbian, because the resulting package depends on a Raspbian-specific library, `/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so`, which is an _optimised memcpy/memset implementation for ARM11 used in Raspberry Pi_.

**Drive-by fixes**:
  * allow `cache` to be a symbolic link in `.gitignore`
  * stop enumerating all supported OS'es with no package management
  * use `if grep` consistently in `paver.sh`.

How to test
--------------
Please review changes.
Build the updated package on our RPi running Raspbian 7.8.

reviewer: @adiroiban 