### PR TITLE
[#2743] Stop using the DEFAULT_VALUES file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build/
 dist/
-DEFAULT_VALUES
 build-*/
 cache

--- a/chevah_build
+++ b/chevah_build
@@ -61,7 +61,10 @@ TIMESTAMP=`date +'%Y%m%d'`
 # package. This way we are able to force a 32bit build on a 64bit machine,
 # for example by exporting ARCH in paver.sh as "x86" instead of "x64" or
 # "ppc" instead of "ppc64".
-# We also use $ARCH when building the statically compiled libffi and GMP.
+# We also use $ARCH when building the statically compiled libffi and GMP,
+# thus the need to export it.
+# Calling the new Python binary when installing the dependencies in paver.sh
+# also requires this to be exported.
 export ARCH
 # Explicitly choose the C compiler in order to make it possible to switch
 # between native compilers and GCC on platforms such as AIX and Solaris.

--- a/chevah_build
+++ b/chevah_build
@@ -8,6 +8,9 @@
 # publish_staging
 #
 
+# Script initialization.
+set -o pipefail
+
 # Import shared code.
 . ./functions.sh
 

--- a/chevah_build
+++ b/chevah_build
@@ -43,16 +43,16 @@ PROG=$0
 DIST_FOLDER='dist'
 BUILD_FOLDER='build'
 
-# Get default values from main paver script.
-./paver.sh detect_os
+# Get default values from main paver script through the env variable.
+OS_DEFAULT_VALUES=`./paver.sh detect_os`
 if [ "$?" -ne 0 ]; then
+    echo "Error detecting OS. Please check './paver.sh detect_os'."
     exit 1
 fi
-PYTHON_VERSION=`cut -d' ' -f 2 DEFAULT_VALUES`
-OS=`cut -d' ' -f 3 DEFAULT_VALUES`
-ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
+PYTHON_VERSION=`echo $OS_DEFAULT_VALUES | cut -d' ' -f 2`
+OS=`echo $OS_DEFAULT_VALUES | cut -d' ' -f 3`
+ARCH=`echo $OS_DEFAULT_VALUES | cut -d' ' -f 4`
 TIMESTAMP=`date +'%Y%m%d'`
-rm DEFAULT_VALUES
 
 # In Solaris and AIX we use $ARCH to choose if we build a 32bit or 64bit
 # package. This way we are able to force a 32bit build on a 64bit machine,

--- a/paver.sh
+++ b/paver.sh
@@ -312,14 +312,14 @@ install_dependencies(){
     exit_code=$?
     set -e
     if [ $exit_code -ne 0 ]; then
-        echo 'Failed to run the inital "paver deps" command.'
+        echo 'Failed to run the initial "paver deps" command.'
         exit 1
     fi
 }
 
 
 #
-# Chech that we have a pavement.py in the current dir.
+# Check that we have a pavement.py in the current dir.
 # otherwise it means we are out of the source folder and paver can not be
 # used there.
 #
@@ -493,7 +493,7 @@ detect_os() {
         ARCH='sparc64'
     elif [ "$ARCH" = "ppc64" ]; then
         # Python has not been fully tested on AIX when compiled as a 64 bit
-        # application and has math rounding error problems (at least with XL C).
+        # binary, and has math rounding error problems (at least with XL C).
         ARCH='ppc'
     elif [ "$ARCH" = "aarch64" ]; then
         ARCH='arm64'

--- a/paver.sh
+++ b/paver.sh
@@ -3,7 +3,6 @@
 # See LICENSE for details.
 #
 # Helper script for bootstraping the build system on Unix/Msys.
-# It will write the default values into 'DEFAULT_VALUES' file.
 #
 # To use this script you will need to publish binary archive files for the
 # following components:
@@ -15,7 +14,7 @@
 # It will delegate the argument to the paver script, with the exception of
 # these commands:
 # * clean - remove everything, except cache
-# * detect_os - create DEFAULT_VALUES and exit
+# * detect_os - detect OS and output values accordingly for OS_DEFAULT_VALUES
 # * get_python - download Python distribution in cache
 # * get_agent - download Rexx/Putty distribution in cache
 #
@@ -72,8 +71,6 @@ clean_build() {
     delete_folder ${DIST_FOLDER}
     echo "Removing publish..."
     delete_folder 'publish'
-    echo "Cleaning project temporary files..."
-    rm -f DEFAULT_VALUES
     echo "Cleaning pyc files ..."
     if [ $OS = "rhel4" ]; then
         # RHEL 4 don't support + option in -exec
@@ -158,7 +155,8 @@ update_path_variables() {
 
 
 write_default_values() {
-    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH} > DEFAULT_VALUES
+    # We used to write them to a temp file, but now we write them to output.
+    echo ${BUILD_FOLDER} ${PYTHON_VERSION} ${OS} ${ARCH}
 }
 
 


### PR DESCRIPTION
Problem
----------
We write OS-dependent values such as PYTHON_VERSION, OS, and ARCH into a temporary file named `DEFAULT_VALUES`.

Solution
----------
Make `detect_os` from `paver.sh` simply output them for `chevah_build` to parse into needed variables.

How to test
--------------
Please review changes.
Check that there is no `DEFAULT_VALUES` file created any more in the current dir when building.
Run the automated tests.

reviewer: @adiroiban 