### PR TITLE
[#3003] No readline for generic Linux.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -52,7 +52,6 @@ PYTHON_VERSION=`cut -d' ' -f 2 DEFAULT_VALUES`
 OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 TIMESTAMP=`date +'%Y%m%d'`
-rm DEFAULT_VALUES
 
 # In Solaris and AIX we use $ARCH to choose if we build a 32bit or 64bit
 # package. This way we are able to force a 32bit build on a 64bit machine,

--- a/chevah_build
+++ b/chevah_build
@@ -298,10 +298,12 @@ command_build() {
     export LDFLAGS="${LDFLAGS} -L$INSTALL_FOLDER/lib/"
 
     # Statically build the BSD libedit on selected platforms to get readline
-    # support without linking to the GPL'ed readline.
+    # support without linking to the GPL-only readline. We don't do this for
+    # generic Linux builds because the result depends on the local ncurses
+    # libs (ncurses, ncursesw, tinfo, others?), and the result is not portable.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
-        ubuntu*|raspbian*|rhel*|sles*|linux|solaris*)
+        ubuntu*|raspbian*|rhel*|sles*|solaris*)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \
                 $INSTALL_FOLDER/include/

--- a/paver.sh
+++ b/paver.sh
@@ -3,7 +3,7 @@
 # See LICENSE for details.
 #
 # Helper script for bootstraping the build system on Unix/Msys.
-# It will write the default values into 'DEFAULT_VALUES' file.
+# It will write the default values in the 'DEFAULT_VALUES' file.
 #
 # To use this script you will need to publish binary archive files for the
 # following components:
@@ -15,7 +15,7 @@
 # It will delegate the argument to the paver script, with the exception of
 # these commands:
 # * clean - remove everything, except cache
-# * detect_os - create DEFAULT_VALUES and exit
+# * detect_os - detect operating system, create the DEFAULT_VALUES file and exit
 # * get_python - download Python distribution in cache
 # * get_agent - download Rexx/Putty distribution in cache
 #
@@ -312,14 +312,14 @@ install_dependencies(){
     exit_code=$?
     set -e
     if [ $exit_code -ne 0 ]; then
-        echo 'Failed to run the inital "paver deps" command.'
+        echo 'Failed to run the initial "paver deps" command.'
         exit 1
     fi
 }
 
 
 #
-# Chech that we have a pavement.py in the current dir.
+# Check that we have a pavement.py in the current dir.
 # otherwise it means we are out of the source folder and paver can not be
 # used there.
 #
@@ -493,7 +493,7 @@ detect_os() {
         ARCH='sparc64'
     elif [ "$ARCH" = "ppc64" ]; then
         # Python has not been fully tested on AIX when compiled as a 64 bit
-        # application and has math rounding error problems (at least with XL C).
+        # binary, and has math rounding error problems (at least with XL C).
         ARCH='ppc'
     elif [ "$ARCH" = "aarch64" ]; then
         ARCH='arm64'

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -76,12 +76,15 @@ def get_allowed_deps():
                 'libtinfo.so.5',
                 ])
         else:
-            # Raspbian is a special case... If this file exists, we assume the
-            # distro passes the more stringent checks in paver.sh during build.
             if os.path.isfile("/etc/rpi-issue"):
+                # Raspbian is special... If this file exists, we assume the
+                # distro passes the tougher checks in paver.sh during build.
+                test_for_readline = True
                 allowed_deps.extend([
                     'libcofi_rpi.so',
                     'libgcc_s.so.1',
+                    'libncurses.so.5',
+                    'libtinfo.so.5',
                     ])
     elif platform_system == 'aix':
         # This is the standard list of deps for AIX 5.3. Some of the links

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -7,6 +7,7 @@ import subprocess
 
 script_helper = './get_binaries_deps.sh'
 platform_system = platform.system().lower()
+test_for_readline = False
 
 
 def get_allowed_deps():
@@ -36,6 +37,7 @@ def get_allowed_deps():
         # Distro-specific deps to add. Now we may specify major versions too.
         linux_distro_name = platform.linux_distribution()[0]
         if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
+            test_for_readline = True
             allowed_deps.extend([
                 'libcom_err.so.2',
                 'libgssapi_krb5.so.2',
@@ -62,12 +64,14 @@ def get_allowed_deps():
                     'libpcre.so.1',
                     ])
         elif ('SUSE' in linux_distro_name):
+            test_for_readline = True
             sles_version = int(platform.linux_distribution()[1])
             if sles_version == 12:
                 allowed_deps.extend([
                     'libtinfo.so.5',
                     ])
         elif ('Ubuntu' in linux_distro_name):
+            test_for_readline = True
             allowed_deps.extend([
                 'libtinfo.so.5',
                 ])
@@ -79,11 +83,6 @@ def get_allowed_deps():
                     'libcofi_rpi.so',
                     'libgcc_s.so.1',
                     ])
-            # For generic Linux distros, such as Debian.
-            allowed_deps.extend([
-                'libncurses.so.5',
-                'libtinfo.so.5',
-                ])
     elif platform_system == 'aix':
         # This is the standard list of deps for AIX 5.3. Some of the links
         # for these libs moved in newer versions from '/usr/lib/' to '/lib/'.
@@ -108,6 +107,7 @@ def get_allowed_deps():
                 'libthread.a',
                 ])
     elif platform_system == 'sunos':
+        test_for_readline = True
         # This is the common list of deps for Solaris 10 & 11 builds.
         allowed_deps = [
             'libc.so.1',
@@ -317,7 +317,7 @@ def main():
             exit_code = 12
 
     # We compile the readline module using libedit only on selected platforms.
-    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
+    if test_for_readline:
         try:
             import readline
             readline.get_history_length()

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -35,8 +35,9 @@ def get_allowed_deps():
             'linux-vdso.so',
             ]
         # Distro-specific deps to add. Now we may specify major versions too.
-        linux_distro_name = platform.linux_distribution()[0]
-        if ('Red Hat' in linux_distro_name) or ('CentOS' in linux_distro_name):
+        with open('../DEFAULT_VALUES') as default_values_file:
+            chevah_os = default_values_file.read().split(' ')[2]
+        if ('rhel' in chevah_os):
             test_for_readline = True
             allowed_deps.extend([
                 'libcom_err.so.2',
@@ -45,7 +46,7 @@ def get_allowed_deps():
                 'libkrb5.so.3',
                 'libresolv.so.2',
                 ])
-            rhel_version = int(platform.linux_distribution()[1].split('.')[0])
+            rhel_version = int(chevah_os[4:])
             if rhel_version >= 5:
                 allowed_deps.extend([
                     'libkeyutils.so.1',
@@ -63,29 +64,26 @@ def get_allowed_deps():
                     'liblzma.so.5',
                     'libpcre.so.1',
                     ])
-        elif ('SUSE' in linux_distro_name):
+        elif ('sles' in chevah_os):
             test_for_readline = True
-            sles_version = int(platform.linux_distribution()[1])
+            sles_version = int(chevah_os[4:])
             if sles_version == 12:
                 allowed_deps.extend([
                     'libtinfo.so.5',
                     ])
-        elif ('Ubuntu' in linux_distro_name):
+        elif ('ubuntu' in chevah_os):
             test_for_readline = True
             allowed_deps.extend([
                 'libtinfo.so.5',
                 ])
-        else:
-            if os.path.isfile("/etc/rpi-issue"):
-                # Raspbian is special... If this file exists, we assume the
-                # distro passes the tougher checks in paver.sh during build.
-                test_for_readline = True
-                allowed_deps.extend([
-                    'libcofi_rpi.so',
-                    'libgcc_s.so.1',
-                    'libncurses.so.5',
-                    'libtinfo.so.5',
-                    ])
+        elif ('raspbian' in chevah_os):
+            test_for_readline = True
+            allowed_deps.extend([
+                'libcofi_rpi.so',
+                'libgcc_s.so.1',
+                'libncurses.so.5',
+                'libtinfo.so.5',
+                ])
     elif platform_system == 'aix':
         # This is the standard list of deps for AIX 5.3. Some of the links
         # for these libs moved in newer versions from '/usr/lib/' to '/lib/'.


### PR DESCRIPTION
Problem
----------
We build the generic Linux builds on Debian, where the readline modules gets linked to `libtinfo.so.5`, which is only present on SLES 12 and Debian-derived distros such as Ubuntu.

On my Gentoo Hardened workstation, readline support is broken:
```
% cache/python2.7-linux-x64/bin/python 
Python 2.7.8 (default, Aug 10 2015, 13:22:11) 
[GCC 4.7.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import readline
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: libtinfo.so.5: cannot open shared object file: No such file or directory
>>> 
```
Solution
----------
We should only enable readline support for selected distros, where we compile the package linked to the corresponding `ncurses` libs.

**Drive-by fixes**:
  * ported latest `paver.sh` fixes from brink
  * rewrote Linux distro detection in Python tests to use the `DEFAULT_VALUES` file.

How to test
--------------
Please review the changes.
Run the tests.

reviewer: @adiroiban 