### PR TITLE
[#3050] AIX 6.1 support.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -103,7 +103,7 @@ def get_allowed_deps():
             ]
         # sys.platform could be 'aix5', 'aix6' etc.
         aix_version = int(sys.platform[-1])
-        if aix_version >= 7:
+        if aix_version >= 6:
             allowed_deps.extend([
                 'libthread.a',
                 ])


### PR DESCRIPTION
Problem
----------
The deps test fails in AIX 6.1 with:
```
Got unwanted deps:
/lib/libthread.a(shr.o)
```
Solution
----------
Patch the script accordingly.

How to test
--------------
Please review the change.
Run the tests on the AIX slaves.

reviewer: @adiroiban 