### PR TITLE
[#3142] FreeBSD support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -149,6 +149,10 @@ case $OS in
         export CFLAGS="$CFLAGS -mmacosx-version-min=10.8"
         export MACOSX_DEPLOYMENT_TARGET=10.8
         ;;
+    freebsd*)
+        export CC="clang"
+        export CXX="clang++"
+        ;;
     rhel4)
         # RHEL4 has OpenSSL 0.9.7, but Python 2 versions starting with
         # 2.7.9 do not support it, see https://bugs.python.org/issue20981.

--- a/paver.sh
+++ b/paver.sh
@@ -483,6 +483,15 @@ detect_os() {
         # For now, no matter the actual OS X version returned, we use '108'.
         OS="osx108"
 
+    elif [ "${OS}" = "freebsd" ]; then
+        ARCH=$(uname -m)
+
+        os_version_raw=$(uname -r | cut -d'.' -f1)
+        check_os_version "FreeBSD" 10 "$os_version_raw" os_version_chevah
+
+        # For now, no matter the actual FreeBSD version returned, we use '10'.
+        OS="freebsd10"
+
     elif [ "${OS}" = "openbsd" ]; then
         ARCH=$(uname -m)
 


### PR DESCRIPTION
Why?
------
To support FreeBSD.

Solution?
-----------
Patched `paver.sh` to support FreeBSD 10.x and newer.
Patched `chevah_build` to use Clang in FreeBSD.

How to test?
-------------
Please review the changes.
Run the tests.

reviewer: @adiroiban 