### PR TITLE
[#3381] Add DBM support in Python.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -417,12 +417,21 @@ def main():
             exit_code = 10
 
 
-    if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
+    if platform_system in ['linux', 'sunos']:
         try:
             import spwd
             spwd
         except:
             sys.stderr.write('"spwd" missing.\n')
+            exit_code = 1
+
+    if platform_system ['openbsd', 'freebsd']:
+        try:
+            import dbm
+            import whichdb
+            dbm.open('/etc/pwd')
+        except:
+            sys.stderr.write('"dbm" missing.\n')
             exit_code = 1
 
     # We compile the readline module using libedit only on selected platforms.


### PR DESCRIPTION
# Scope

we need the 'dbm' module in our python distribution on freebsd and openbsd

At the low level that is _bsddb 
# Changes

updated tests

for now this is abadoned since we are using https://github.com/jamesls/semidbm
# How to test

WIP
