### PR TITLE
[#3418] Build for Ubuntu 16.04 and update Linux, OpenBSD and OSX builds to cffi.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,58 @@
+Scope
+=====
+
+Describe the scope of the changes or the problem that these changes wants
+to solve.
+This content should be created when a ticket is submitted and just link
+the ticket or copy paste the ticket description... or find a way for
+linking this review to a ticket.
+
+depends-on #123 #124
+
+
+Why we got into this (5 whys)
+=============================
+
+Mainly used for bugs. Can be ignored for tasks or new features.
+
+* Describe why we got this problem in the first place.
+* What went wrong.
+* Repeatedly ask the question “Why” (up to 5 times) to determine the
+  root cause of this problem.
+
+
+Changes
+=======
+
+Describe how the problem was fixed.
+
+Briefly describe **all** changes made in a developer friendly way.
+
+Briefly describe the end user changes in a tester friendly way.
+
+List all changes for which an *ideal* solution was not found.
+Describe the current solution.
+
+What was not yet done and link to the ticket for the still to do work.
+
+As a drive-by change add comments about out-of-scope minor drive-by changes.
+
+
+How to try and test the changes
+===============================
+
+reviewers: @robi-net
+
+How the changes can be tested and verified by team members.
+How to run manual tests.
+
+
+Title for first test case
+-------------------------
+
+For end-user changes, how the changes can be tested and verified by
+our users.
+
+List the steps to follow for checking that everything is OK.
+
+Explicitly state the expected results.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -3,22 +3,6 @@ Scope
 
 Describe the scope of the changes or the problem that these changes wants
 to solve.
-This content should be created when a ticket is submitted and just link
-the ticket or copy paste the ticket description... or find a way for
-linking this review to a ticket.
-
-depends-on #123 #124
-
-
-Why we got into this (5 whys)
-=============================
-
-Mainly used for bugs. Can be ignored for tasks or new features.
-
-* Describe why we got this problem in the first place.
-* What went wrong.
-* Repeatedly ask the question “Why” (up to 5 times) to determine the
-  root cause of this problem.
 
 
 Changes
@@ -45,14 +29,3 @@ reviewers: @robi-net
 
 How the changes can be tested and verified by team members.
 How to run manual tests.
-
-
-Title for first test case
--------------------------
-
-For end-user changes, how the changes can be tested and verified by
-our users.
-
-List the steps to follow for checking that everything is OK.
-
-Explicitly state the expected results.

--- a/chevah_build
+++ b/chevah_build
@@ -147,10 +147,10 @@ case $OS in
         fi
         BUILD_CFFI="yes"
         ;;
-    archlinux)
-        # ArchLinux has OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against it
-        # so we use pyOpenSSL 16.0.0 and it's dependency python-cryptography.
-        # Also OpenSSL is built without SSLv3 support, so we need to build
+    archlinux|ubuntu1604)
+        # Newer OS'es have OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against
+	# it, so we use pyOpenSSL > 16.0.0 and its dep: python-cryptography.
+        # Also, when OpenSSL is built without SSLv3 support, we need to build
         # Python and cryptography against it to have them working properly
         # in this environment.
         # cffi is needed to build cryptography.
@@ -213,12 +213,6 @@ case $OS in
         # RHEL4 has OpenSSL 0.9.7, but Python 2 versions starting with
         # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
         PYTHON_BUILD_VERSION=2.7.8
-        ;;
-    ubuntu1604)
-        # Latest Ubuntu version uses the new CFFI based libraries.
-        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
-        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
-        BUILD_CFFI="yes"
         ;;
     windows*)
         # On Windows, python executable is installed at a different path.

--- a/chevah_build
+++ b/chevah_build
@@ -8,9 +8,6 @@
 # publish_staging
 #
 
-# Import shared code.
-. ./functions.sh
-
 # List of OS packages required for building Python.
 COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
 DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
@@ -34,6 +31,8 @@ PYTHON_BUILD_VERSION=2.7.10
 PYSQLITE_VERSION=2.6.3
 SQLITE_VERSION=3.8.1
 
+REDISTRIBUTABLE_VERSION="9.00.30729.6161"
+
 # pycparser needs to be explicitly installed to work around setuptools auto
 # dependencies.
 PYCPARSER_VERSION=2.14
@@ -54,6 +53,7 @@ EXTRA_LIBRARIES_CFFI="\
 # Empty here for now as we only use it some systems.
 # This should be populated with PIP_LIBRARIES_EVERYWHERE once non using
 # pip to install c modules is an exception.
+# On windows make sure you have cryptography binary wheel on pypi.
 PIP_LIBRARIES=""
 PIP_LIBRARIES_EVERYWHERE="\
     cryptography==1.3.1 \
@@ -74,6 +74,9 @@ PIP_ARGS="\
 PROG=$0
 DIST_FOLDER='dist'
 BUILD_FOLDER='build'
+
+# Import shared code.
+. ./functions.sh
 
 # Get default values from main paver script.
 ./paver.sh detect_os
@@ -109,10 +112,10 @@ PYTHON_BUILD_FOLDER="$PYTHON_VERSION-$OS-$ARCH"
 
 export MAKE=make
 
-# Used when building cffi on ArchLinux
+# Used when building cffi.
 export CHEVAH_BUILD_PATH=$INSTALL_FOLDER
-# Used when building python on Windows or ArchLinux
-export PIP_ARGS
+# Used when building on Windows.
+export REDISTRIBUTABLE_VERSION
 
 case $OS in
     aix*)
@@ -220,6 +223,7 @@ case $OS in
     windows*)
         # On Windows, python executable is installed at a different path.
         LOCAL_PYTHON_BINARY=./$LOCAL_PYTHON_BINARY_DIST/lib/python
+        PYTHON_BIN=$INSTALL_FOLDER/lib/python
         # On windows extra libraries are installed only using PIP.
         EXTRA_LIBRARIES=""
         PIP_LIBRARIES=$PIP_LIBRARIES_WIN
@@ -437,7 +441,7 @@ command_build() {
 #
 command_build_sqlite() {
 
-    if [ $OS = 'windows']; then
+    if [ $OS = 'windows' ]; then
         echo "Skipping sqlite on Windows"
         return
     fi
@@ -466,25 +470,23 @@ command_build_sqlite() {
 command_build_python_extra_libraries() {
 
     # Install the latest PIP and setuptools.
-    execute $INSTALL_FOLDER/bin/python python-modules/get-pip.py $PIP_ARGS
+    execute $PYTHON_BIN python-modules/get-pip.py $PIP_ARGS
 
     # pycparser is installed first as setup_requires is ugly.
     # https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires
     execute $PYTHON_BIN -m pip \
         install $PIP_ARGS -U pycparser==$PYCPARSER_VERSION
 
-    # Update Python config Makefile to use the python that we have just
-    # created.
-    makefile=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile
-    makefile_orig=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile.orig
-    execute cp $makefile $makefile_orig
-    sed "s#^prefix=.*#prefix= $INSTALL_FOLDER#" $makefile_orig > $makefile
-
-    # We need GMP or MPIR for fast math in PyCrypto. We use GMP because
-    # its devs do a better job of supporting exotic platforms such as AIX.
-    # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
-    cp $INSTALL_FOLDER/tmp/gmp/gmp.h $INSTALL_FOLDER/include
-    cp $INSTALL_FOLDER/tmp/gmp/libgmp* $INSTALL_FOLDER/lib
+    if [ $OS = 'windows' ]; then
+        echo "Skipping makefile updating on Windows"
+    else
+        # Update Python config Makefile to use the python that we have just
+        # created.
+        makefile=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile
+        makefile_orig=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile.orig
+        execute cp $makefile $makefile_orig
+        sed "s#^prefix=.*#prefix= $INSTALL_FOLDER#" $makefile_orig > $makefile
+    fi
 
     for library in $EXTRA_LIBRARIES ; do
         # Library is in the form pyopenssl/PyOpenssl-2.4.5
@@ -500,9 +502,27 @@ command_build_python_extra_libraries() {
     done
 
     for library in $PIP_LIBRARIES ; do
-        execute $PYTHON_BIN -m pip \
-            install $PIP_ARGS $library
+        execute $PYTHON_BIN -m pip install $PIP_ARGS $library
     done
+
+    if [ $OS == "windows" ]; then
+        echo "Patching pyWin32 manifests to use our redistributable version"
+        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/win32/pythonservice.exe
+        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/win32/perfmondata.dll
+        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/pywin32_system32/pythoncomloader27.dll
+
+        echo "Copy Python runtime to pyWin32 package"
+        execute cp $INSTALL_FOLDER/*CRT.manifest \
+            $INSTALL_FOLDER/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/python27.dll.manifest \
+            $INSTALL_FOLDER/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/python27.dll \
+            $INSTALL_FOLDER/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/msvc?90.dll \
+            $INSTALL_FOLDER/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/Lib/site-packages/pywin32_system32/*.dll \
+            $INSTALL_FOLDER/Lib/site-packages/win32/
+    fi
 
     execute mv $makefile_orig $makefile
 }

--- a/chevah_build
+++ b/chevah_build
@@ -149,7 +149,7 @@ case $OS in
         ;;
     archlinux|ubuntu1604)
         # Newer OS'es have OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against
-	# it, so we use pyOpenSSL > 16.0.0 and its dep: python-cryptography.
+        # it, so we use pyOpenSSL >= 16.0.0 and its dep, python-cryptography.
         # Also, when OpenSSL is built without SSLv3 support, we need to build
         # Python and cryptography against it to have them working properly
         # in this environment.

--- a/chevah_build
+++ b/chevah_build
@@ -34,14 +34,36 @@ PYTHON_BUILD_VERSION=2.7.10
 PYSQLITE_VERSION=2.6.3
 SQLITE_VERSION=3.8.1
 
-EXTRA_LIBRARIES="\
-   python-modules/pyOpenSSL-0.13 \
-   python-modules/pycrypto-2.6.1 \
-   python-modules/python-setproctitle-1.1.8.dev0 \
-   "
+# pycparser needs to be explicitly installed to work around setuptools auto
+# dependencies.
+PYCPARSER_VERSION=2.14
 
-# Empty here for now as we only use it in ArchLinux.
+EXTRA_LIBRARIES="\
+    python-modules/pyOpenSSL-0.13 \
+    python-modules/pycrypto-2.6.1 \
+    python-modules/python-setproctitle-1.1.8.dev0 \
+    "
+BUILD_CFFI="no"
+# Extra libraries used by the cffi based bindings outside of Windows.
+EXTRA_LIBRARIES_CFFI="\
+    python-modules/cffi-1.5.2 \
+    python-modules/pycrypto-2.6.1 \
+    python-modules/python-setproctitle-1.1.8.dev0 \
+    "
+
+# Empty here for now as we only use it some systems.
+# This should be populated with PIP_LIBRARIES_EVERYWHERE once non using
+# pip to install c modules is an exception.
 PIP_LIBRARIES=""
+PIP_LIBRARIES_EVERYWHERE="\
+    cryptography==1.3.1 \
+    pyOpenSSL==16.0.0
+    "
+# Pre-combiled libraries distributed as wheels for Windows.
+PIP_LIBRARIES_WIN="$PIP_LIBRARIES_EVERYWHERE \
+    pypiwin32==219 \
+    pycrypto==2.6.1 \
+    "
 
 # Arguments that are sent when using pip.
 PIP_ARGS="\
@@ -120,6 +142,18 @@ case $OS in
                 export CFLAGS="$CFLAGS -qmaxmem=-1 -q64"
             fi
         fi
+        BUILD_CFFI="yes"
+        ;;
+    archlinux)
+        # ArchLinux has OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against it
+        # so we use pyOpenSSL 16.0.0 and it's dependency python-cryptography.
+        # Also OpenSSL is built without SSLv3 support, so we need to build
+        # Python and cryptography against it to have them working properly
+        # in this environment.
+        # cffi is needed to build cryptography.
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
+        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
+        BUILD_CFFI="yes"
         ;;
     solaris*)
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
@@ -154,11 +188,13 @@ case $OS in
                 export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
             fi
         fi
+        BUILD_CFFI="yes"
         ;;
     hpux*)
         # For HP-UX we haven't managed yet to compile libffi and GMP with the
         # HP compiler, so we are NOT exporting custom values for CC and CXX.
         export MAKE=gmake
+        BUILD_CFFI="yes"
         ;;
     osx*)
         export CC="clang"
@@ -175,26 +211,19 @@ case $OS in
         # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
         PYTHON_BUILD_VERSION=2.7.8
         ;;
+    ubuntu1604)
+        # Latest Ubuntu version uses the new CFFI based libraries.
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
+        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
+        BUILD_CFFI="yes"
+        ;;
     windows*)
         # On Windows, python executable is installed at a different path.
         LOCAL_PYTHON_BINARY=./$LOCAL_PYTHON_BINARY_DIST/lib/python
-        ;;
-    archlinux)
-        # ArchLinux has OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against it
-        # so we use pyOpenSSL 16.0.0 and it's dependency python-cryptography.
-        # Also OpenSSL is built without SSLv3 support, so we need to build
-        # Python and cryptography against it to have them working properly
-        # in this environment.
-        # cffi is needed to build cryptography.
-
-        EXTRA_LIBRARIES="\
-           python-modules/cffi-1.5.2 \
-           python-modules/pycrypto-2.6.1 \
-           python-modules/python-setproctitle-1.1.8.dev0 \
-        "
-        PIP_LIBRARIES="\
-            pyOpenSSL==16.0.0
-        "
+        # On windows extra libraries are installed only using PIP.
+        EXTRA_LIBRARIES=""
+        PIP_LIBRARIES=$PIP_LIBRARIES_WIN
+        BUILD_CFFI="no"
         ;;
 esac
 
@@ -336,11 +365,9 @@ command_build() {
     # Clean the build dir to avoid contamination from previous builds.
     command_clean
 
-    case $OS in
-        aix*|solaris*|hpux*|archlinux)
-            build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
-            ;;
-    esac
+    if [ $BUILD_CFFI == "yes" ]; then
+        build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
+    fi
 
     case $OS in
         windows*)
@@ -374,20 +401,15 @@ command_build() {
             ;;
     esac
 
+    build 'python' "Python-$PYTHON_BUILD_VERSION" ${PYTHON_BUILD_FOLDER}
+    command_build_sqlite
+    command_build_python_extra_libraries
+
     case $OS in
         windows*)
-            build 'python' "Python-$PYTHON_BUILD_VERSION-windows" ${PYTHON_BUILD_FOLDER}
-            echo "Skipping sqlite and extra libraries"
-            # For Windows we don't build every thing from source yet.
             echo "Skipping cleaning install folder"
             ;;
         *)
-            build 'python' "Python-$PYTHON_BUILD_VERSION" ${PYTHON_BUILD_FOLDER}
-
-            command_build_sqlite
-
-            command_build_python_extra_libraries
-
             execute pushd ${BUILD_FOLDER}/${PYTHON_BUILD_FOLDER}
                 # Clean the build folder.
                 execute rm -rf tmp
@@ -412,6 +434,12 @@ command_build() {
 # Build pysqlite with static linked SQLite.
 #
 command_build_sqlite() {
+
+    if [ $OS = 'windows']; then
+        echo "Skipping sqlite on Windows"
+        return
+    fi
+
     target_folder=${BUILD_FOLDER}/pysqlite
     amalgamation_folder=${BUILD_FOLDER}/pysqlite/amalgamation
 
@@ -434,6 +462,15 @@ command_build_sqlite() {
 # Compile and install all Python extra libraries.
 #
 command_build_python_extra_libraries() {
+
+    # Install the latest PIP and setuptools.
+    execute $INSTALL_FOLDER/bin/python python-modules/get-pip.py $PIP_ARGS
+
+    # pycparser is installed first as setup_requires is ugly.
+    # https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires
+    execute $PYTHON_BIN -m pip \
+        install $PIP_ARGS -U pycparser==$PYCPARSER_VERSION
+
     # Update Python config Makefile to use the python that we have just
     # created.
     makefile=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile

--- a/chevah_build
+++ b/chevah_build
@@ -31,36 +31,33 @@ PYTHON_BUILD_VERSION=2.7.10
 PYSQLITE_VERSION=2.6.3
 SQLITE_VERSION=3.8.1
 
+# The ID of the redistributable version used on Windows.
 REDISTRIBUTABLE_VERSION="9.00.30729.6161"
 
 # pycparser needs to be explicitly installed to work around setuptools auto
 # dependencies.
 PYCPARSER_VERSION=2.14
 
+BUILD_CFFI="yes"
 EXTRA_LIBRARIES="\
-    python-modules/pyOpenSSL-0.13 \
-    python-modules/pycrypto-2.6.1 \
-    python-modules/python-setproctitle-1.1.8.dev0 \
-    "
-BUILD_CFFI="no"
-# Extra libraries used by the cffi based bindings outside of Windows.
-EXTRA_LIBRARIES_CFFI="\
     python-modules/cffi-1.5.2 \
     python-modules/pycrypto-2.6.1 \
     python-modules/python-setproctitle-1.1.8.dev0 \
     "
+# Libraries for legecy systems not built around cffi.
+EXTRA_LIBRARIES_NO_CFFI="\
+    python-modules/pyOpenSSL-0.13 \
+    python-modules/pycrypto-2.6.1 \
+    python-modules/python-setproctitle-1.1.8.dev0 \
+    "
 
-# Empty here for now as we only use it some systems.
-# This should be populated with PIP_LIBRARIES_EVERYWHERE once non using
-# pip to install c modules is an exception.
-# On windows make sure you have cryptography binary wheel on pypi.
-PIP_LIBRARIES=""
-PIP_LIBRARIES_EVERYWHERE="\
+# List of python modules installed using pip
+PIP_LIBRARIES="\
     cryptography==1.3.1 \
     pyOpenSSL==16.0.0
     "
 # Pre-combiled libraries distributed as wheels for Windows.
-PIP_LIBRARIES_WIN="$PIP_LIBRARIES_EVERYWHERE \
+PIP_LIBRARIES_WIN="$PIP_LIBRARIES \
     pypiwin32==219 \
     pycrypto==2.6.1 \
     "
@@ -145,18 +142,9 @@ case $OS in
                 export CFLAGS="$CFLAGS -qmaxmem=-1 -q64"
             fi
         fi
-        BUILD_CFFI="yes"
-        ;;
-    archlinux|ubuntu*|linux|sles*|rhel*|raspbian*|openbsd*)
-        # Newer OS'es have OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against
-        # it, so we use pyOpenSSL >= 16.0.0 and its dep, python-cryptography.
-        # Also, when OpenSSL is built without SSLv3 support, we need to build
-        # Python and cryptography against it to have them working properly
-        # in this environment.
-        # cffi is needed to build cryptography.
-        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
-        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
-        BUILD_CFFI="yes"
+        # On AIX cffi based modules are not ported yet.
+        PIP_LIBRARIES=""
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     solaris*)
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
@@ -190,31 +178,28 @@ case $OS in
             else
                 export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
             fi
-        else
-            # On Solaris 11 we can build the new libraries.
-            EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
-            PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
+            # cffi modules are not ready yet.
+            PIP_LIBRARIES=""
+            EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         fi
-        BUILD_CFFI="yes"
         ;;
     hpux*)
         # For HP-UX we haven't managed yet to compile libffi and GMP with the
         # HP compiler, so we are NOT exporting custom values for CC and CXX.
         export MAKE=gmake
-        BUILD_CFFI="yes"
         ;;
     osx*)
         export CC="clang"
         export CXX="clang++"
         export CFLAGS="$CFLAGS -mmacosx-version-min=10.8"
         export MACOSX_DEPLOYMENT_TARGET=10.8
-        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
-        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
-        BUILD_CFFI="yes"
         ;;
     freebsd*)
         export CC="clang"
         export CXX="clang++"
+        # cffi modules are not ready yet.
+        PIP_LIBRARIES=""
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     windows*)
         # On Windows, python executable is installed at a different path.
@@ -581,6 +566,7 @@ initialize_python_module(){
 help_text_test=\
 "Run a quick test for the Python from build."
 command_test() {
+    export BUILD_CFFI
     test_file='test_python_binary_dist.py'
     execute mkdir -p build/
     execute cp python-modules/chevah-python-test/${test_file} build/

--- a/chevah_build
+++ b/chevah_build
@@ -38,6 +38,7 @@ REDISTRIBUTABLE_VERSION="9.00.30729.6161"
 # dependencies.
 PYCPARSER_VERSION=2.14
 
+BUILD_LIBFFI="yes"
 BUILD_CFFI="yes"
 EXTRA_LIBRARIES="\
     python-modules/cffi-1.5.2 \
@@ -143,6 +144,7 @@ case $OS in
             fi
         fi
         # On AIX cffi based modules are not ported yet.
+        BUILD_CFFI="no"
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
@@ -180,6 +182,7 @@ case $OS in
             fi
         fi
         # cffi modules are not ready yet on Solaris.
+        BUILD_CFFI="no"
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
@@ -198,6 +201,7 @@ case $OS in
         export CC="clang"
         export CXX="clang++"
         # cffi modules are not ready yet.
+        BUILD_CFFI="no"
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
@@ -208,8 +212,8 @@ case $OS in
         # On windows extra libraries are installed only using PIP.
         EXTRA_LIBRARIES=""
         PIP_LIBRARIES=$PIP_LIBRARIES_WIN
-        # We don't build cffi as it is available as a wheel in pypi.
-        BUILD_CFFI="no"
+        # We don't build libffi, as cffi it is available as a wheel in pypi.
+        BUILD_LIBFFI="no"
         PYTHON_BUILD_VERSION="$PYTHON_BUILD_VERSION-windows"
         ;;
 esac
@@ -352,7 +356,7 @@ command_build() {
     # Clean the build dir to avoid contamination from previous builds.
     command_clean
 
-    if [ $BUILD_CFFI == "yes" ]; then
+    if [ $BUILD_LIBFFI == "yes" ]; then
         build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
     fi
 

--- a/chevah_build
+++ b/chevah_build
@@ -478,6 +478,7 @@ command_build_python_extra_libraries() {
         # created.
         makefile=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile
         makefile_orig=$INSTALL_FOLDER/lib/$PYTHON_VERSION/config/Makefile.orig
+
         execute cp $makefile $makefile_orig
         sed "s#^prefix=.*#prefix= $INSTALL_FOLDER#" $makefile_orig > $makefile
     fi
@@ -501,24 +502,23 @@ command_build_python_extra_libraries() {
 
     if [ $OS == "windows" ]; then
         echo "Patching pyWin32 manifests to use our redistributable version"
-        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/win32/pythonservice.exe
-        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/win32/perfmondata.dll
-        wipe_manifest $INSTALL_FOLDER/Lib/site-packages/pywin32_system32/pythoncomloader27.dll
+        wipe_manifest $INSTALL_FOLDER/lib/Lib/site-packages/win32/pythonservice.exe
+        wipe_manifest $INSTALL_FOLDER/lib/Lib/site-packages/win32/perfmondata.dll
+        wipe_manifest $INSTALL_FOLDER/lib/Lib/site-packages/pywin32_system32/pythoncomloader27.dll
 
         echo "Copy Python runtime to pyWin32 package"
-        execute cp $INSTALL_FOLDER/*CRT.manifest \
-            $INSTALL_FOLDER/Lib/site-packages/win32/
-        execute cp $INSTALL_FOLDER/python27.dll.manifest \
-            $INSTALL_FOLDER/Lib/site-packages/win32/
-        execute cp $INSTALL_FOLDER/python27.dll \
-            $INSTALL_FOLDER/Lib/site-packages/win32/
-        execute cp $INSTALL_FOLDER/msvc?90.dll \
-            $INSTALL_FOLDER/Lib/site-packages/win32/
-        execute cp $INSTALL_FOLDER/Lib/site-packages/pywin32_system32/*.dll \
-            $INSTALL_FOLDER/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/lib/*CRT.manifest \
+            $INSTALL_FOLDER/lib/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/lib/python27.dll.manifest \
+            $INSTALL_FOLDER/lib/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/lib/python27.dll \
+            $INSTALL_FOLDER/lib/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/lib/msvc?90.dll \
+            $INSTALL_FOLDER/lib/Lib/site-packages/win32/
+        execute cp $INSTALL_FOLDER/lib/Lib/site-packages/pywin32_system32/*.dll \
+            $INSTALL_FOLDER/lib/Lib/site-packages/win32/
     fi
 
-    execute mv $makefile_orig $makefile
 }
 
 

--- a/chevah_build
+++ b/chevah_build
@@ -147,7 +147,7 @@ case $OS in
         fi
         BUILD_CFFI="yes"
         ;;
-    archlinux|ubuntu1604)
+    archlinux|ubuntu*|linux|sles*|rhel*|raspbian*|openbsd*)
         # Newer OS'es have OpenSSL >= 1.0.2, pyOpenSSL 0.13 won't build against
         # it, so we use pyOpenSSL >= 16.0.0 and its dep, python-cryptography.
         # Also, when OpenSSL is built without SSLv3 support, we need to build
@@ -190,6 +190,10 @@ case $OS in
             else
                 export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
             fi
+        else
+            # On Solaris 11 we can build the new libraries.
+            EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
+            PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
         fi
         BUILD_CFFI="yes"
         ;;
@@ -204,15 +208,13 @@ case $OS in
         export CXX="clang++"
         export CFLAGS="$CFLAGS -mmacosx-version-min=10.8"
         export MACOSX_DEPLOYMENT_TARGET=10.8
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_CFFI
+        PIP_LIBRARIES=$PIP_LIBRARIES_EVERYWHERE
+        BUILD_CFFI="yes"
         ;;
     freebsd*)
         export CC="clang"
         export CXX="clang++"
-        ;;
-    rhel4)
-        # RHEL4 has OpenSSL 0.9.7, but Python 2 versions starting with
-        # 2.7.9 do not support it, see https://bugs.python.org/issue20981.
-        PYTHON_BUILD_VERSION=2.7.8
         ;;
     windows*)
         # On Windows, python executable is installed at a different path.

--- a/chevah_build
+++ b/chevah_build
@@ -223,7 +223,9 @@ case $OS in
         # On windows extra libraries are installed only using PIP.
         EXTRA_LIBRARIES=""
         PIP_LIBRARIES=$PIP_LIBRARIES_WIN
+        # We don't build cffi as it is available as a wheel in pypi.
         BUILD_CFFI="no"
+        PYTHON_BUILD_VERSION="$PYTHON_BUILD_VERSION-windows"
         ;;
 esac
 

--- a/chevah_build
+++ b/chevah_build
@@ -178,10 +178,10 @@ case $OS in
             else
                 export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
             fi
-            # cffi modules are not ready yet.
-            PIP_LIBRARIES=""
-            EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         fi
+        # cffi modules are not ready yet on Solaris.
+        PIP_LIBRARIES=""
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     hpux*)
         # For HP-UX we haven't managed yet to compile libffi and GMP with the

--- a/functions.sh
+++ b/functions.sh
@@ -211,3 +211,25 @@ safe_move() {
 }
 
 
+#
+# Wipe the manifest of source.
+#
+wipe_manifest() {
+    local source=$1
+    local manifest_wiper=$CHEVAH_BUILD_PATH/../../win-tools/manifest-wiper.exe
+
+    echo "Extracting manifests for $source"
+    execute $manifest_wiper --verbose --extract ${source}.embedded $source
+
+    echo "Patching manifests to use our redistributable version"
+    # FIXME:
+    # Use $REDISTRIBUTABLE_VERSION for version matching here.
+    execute sed -e \
+        's|version="9.0.21022.8"|version="9.00.30729.6161"|' \
+        -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' \
+        < ${source}.embedded \
+        > ${source}.manifest
+
+    execute rm -f --verbose ${source}.embedded
+
+}

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -10,6 +10,7 @@ platform_system = platform.system().lower()
 test_for_readline = False
 with open('../DEFAULT_VALUES') as default_values_file:
     chevah_os = default_values_file.read().split(' ')[2]
+BUILD_CFFI = os.environ.get('BUILD_CFFI', 'no').lower() == 'yes'
 
 
 def get_allowed_deps():
@@ -299,23 +300,8 @@ def main():
         exit_code = 2
 
     # cryptography module and latest pyOpenSSL are only available on
-    # few systems.
-    if chevah_os in [
-        'archlinux',
-        'openbsd58',
-        'osx108',
-        'raspbian7',
-        'rhel5',
-        'rhel6',
-        'rhel7',
-        'sles11',
-        'sles12',
-        'solaris11',
-        'ubuntu1204',
-        'ubuntu1404',
-        'ubuntu1604',
-        'windows',
-            ]:
+    # systems with cffi.
+    if BUILD_CFFI:
         try:
             from cryptography.hazmat.backends.openssl.backend import backend
             import cryptography

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -304,10 +304,9 @@ def main():
         try:
             from cryptography.hazmat.backends.openssl.backend import backend
             import cryptography
+            openssl_version = backend.openssl_version_text()
             print 'cryptography %s - OpenSSL %s' % (
-                cryptography.__version__,
-                backend.openssl_version_text()
-                )
+                cryptography.__version__, openssl_version)
 
             if chevah_os == 'windows':
                 # Check OpenSSL version on windows.
@@ -316,8 +315,8 @@ def main():
                     sys.stderr.write('Expecting %s got %s.\n' % (
                         expecting, openssl_version))
                     exit_code = 3
-        except:
-            sys.stderr.write('"cryptography" failure.\n')
+        except Exception as error:
+            sys.stderr.write('"cryptography" failure. %s\n' % (error,))
             exit_code = 14
 
     try:

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -300,7 +300,22 @@ def main():
 
     # cryptography module and latest pyOpenSSL are only available on
     # few systems.
-    if chevah_os in ['archlinux', 'windows', 'ubuntu1604']:
+    if chevah_os in [
+        'archlinux',
+        'openbsd58',
+        'osx108',
+        'raspbian7',
+        'rhel5',
+        'rhel6',
+        'rhel7',
+        'sles11',
+        'sles12',
+        'solaris11',
+        'ubuntu1204',
+        'ubuntu1404',
+        'ubuntu1604',
+        'windows',
+            ]:
         try:
             from cryptography.hazmat.backends.openssl.backend import backend
             import cryptography

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -298,8 +298,9 @@ def main():
         sys.stderr.write('standard "ssl" missing.\n')
         exit_code = 2
 
-    # cryptography module and pyOpenSSL 16.0.0 are only available on ArchLinux
-    if chevah_os == "archlinux":
+    # cryptography module and latest pyOpenSSL are only available on
+    # few systems.
+    if chevah_os in ['archlinux', 'windows', 'ubuntu1604']:
         try:
             from cryptography.hazmat.backends.openssl.backend import backend
             import cryptography
@@ -307,6 +308,14 @@ def main():
                 cryptography.__version__,
                 backend.openssl_version_text()
                 )
+
+            if chevah_os == 'windows':
+                # Check OpenSSL version on windows.
+                expecting = u'OpenSSL 1.0.2g  1 Mar 2016'
+                if openssl_version != expecting:
+                    sys.stderr.write('Expecting %s got %s.\n' % (
+                        expecting, openssl_version))
+                    exit_code = 3
         except:
             sys.stderr.write('"cryptography" failure.\n')
             exit_code = 14
@@ -383,21 +392,6 @@ def main():
         except:
             sys.stderr.write('"sqlite3" missing.\n')
             exit_code = 6
-
-        # For now cryptography is only available on Winodws
-        try:
-            from cryptography.hazmat.backends.openssl.backend import backend
-            openssl_version = backend.openssl_version_text()
-        except:
-            sys.stderr.write('"cryptography" failure.\n')
-            exit_code = 3
-        else:
-            # Check OpenSSL version.
-            expecting = u'OpenSSL 1.0.2g  1 Mar 2016'
-            if openssl_version != expecting:
-                sys.stderr.write(
-                    'Expecting %s got %s.\n' % (expecting, openssl_version))
-                exit_code = 3
 
     else:
         # Linux and Unix checks.

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -48,6 +48,14 @@ chevahbs_install() {
     execute cp .libs/* $temp_folder
     ranlib $temp_folder/libgmp.a
     execute cp gmp.h $temp_folder
+
+    # We need GMP or MPIR for fast math in PyCrypto. We use GMP because
+    # its devs do a better job of supporting exotic platforms such as AIX.
+    # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
+    mkdir -p $INSTALL_FOLDER/include
+    mkdir -p $INSTALL_FOLDER/lib
+    cp $INSTALL_FOLDER/tmp/gmp/gmp.h $INSTALL_FOLDER/include
+    cp $INSTALL_FOLDER/tmp/gmp/libgmp* $INSTALL_FOLDER/lib
 }
 
 

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -42,6 +42,11 @@ chevahbs_install() {
         # location.
         execute mkdir -p $INSTALL_FOLDER/include
         execute cp $INSTALL_FOLDER/lib/libffi-*/include/* $INSTALL_FOLDER/include
+        # On some systems libffi in installed in /lib64 and then cffi is
+        # searching for it in /lib.
+        # THis affect RHEL, SLES and OpenBSD.
+        cp $INSTALL_FOLDER/lib64/* $INSTALL_FOLDER/lib
+        echo 'cffi done... here to ignore a possible previous error'
     fi
 }
 

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -34,7 +34,7 @@ chevahbs_install() {
 
         execute cp powerpc-ibm-aix*/.libs/* $temp_folder
         execute cp powerpc-ibm-aix*/include/*.h $temp_folder
-    elif [ x${OS}x == x"archlinux"x ]; then
+    else
         execute $MAKE install DESTDIR=$INSTALL_FOLDER
 
         # libffi installs its headers in $PREFIX/lib/libffi-$VERSION/include,

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -34,6 +34,14 @@ chevahbs_install() {
 
         execute cp powerpc-ibm-aix*/.libs/* $temp_folder
         execute cp powerpc-ibm-aix*/include/*.h $temp_folder
+    elif [ "$OS" = "solaris10" ]; then
+        # I don't know why it is skip... but doing the actual install will
+        # break the build.
+        echo 'Skipping installation of libffi on Solaris 10.'
+    elif [ "$OS" = "solaris11" ]; then
+        # I don't know why it is skip... but doing the actual install will
+        # break the build.
+        echo 'Skipping installation of libffi on Solaris 11.'
     else
         execute $MAKE install DESTDIR=$INSTALL_FOLDER
 

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -144,9 +144,6 @@ chevahbs_install() {
             execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/python27.dll.embedded > $destination/python27.dll.manifest
             execute rm -f --verbose $destination/*.embedded
 
-            echo "Installing pip"
-            execute $destination/python $get_pip $PIP_ARGS
-
             echo "Patching pyWin32 manifests to use our redistributable version"
             $manifest_wiper --verbose \
                 --extract $destination/Lib/site-packages/win32/pythonservice.exe.embedded \

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -109,10 +109,6 @@ chevahbs_install() {
     case $OS in
         windows)
             local destination=$INSTALL_FOLDER/lib
-            local redistributables=../../win-tools/redistributables/
-            local redistributable_version=9.00.30729.6161
-            local manifest_wiper=../../win-tools/manifest-wiper.exe
-            local get_pip=../../python-modules/get-pip.py
 
             # On Windows we don't build from source but rather create the
             # distribution from pre-compiled binaries.
@@ -124,49 +120,14 @@ chevahbs_install() {
                 //a $current_win_path\\python-installer.msi \
                 //qn TARGETDIR=$install_win_path\\lib
 
-            echo "Copying redistributables"
-            execute cp $redistributables/$redistributable_version/* $destination
+            # Copy Windows redistributables
+            local redistributables=../../win-tools/redistributables/
+            echo "Copying redistributables for Windows"
+            execute cp $redistributables/$REDISTRIBUTABLE_VERSION/* $destination
 
-            echo "Extracting manifests for python(w).exe and python27.dll"
-            $manifest_wiper --verbose \
-                --extract $destination/python.exe.embedded \
-                $destination/python.exe
-            $manifest_wiper --verbose \
-                --extract $destination/pythonw.exe.embedded \
-                $destination/pythonw.exe
-            $manifest_wiper --verbose \
-                --extract $destination/python27.dll.embedded \
-                $destination/python27.dll
-
-            echo "Patching manifests to use our redistributable version"
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/python.exe.embedded > $destination/python.exe.manifest
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/pythonw.exe.embedded > $destination/pythonw.exe.manifest
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/python27.dll.embedded > $destination/python27.dll.manifest
-            execute rm -f --verbose $destination/*.embedded
-
-            echo "Patching pyWin32 manifests to use our redistributable version"
-            $manifest_wiper --verbose \
-                --extract $destination/Lib/site-packages/win32/pythonservice.exe.embedded \
-                $destination/Lib/site-packages/win32/pythonservice.exe
-            $manifest_wiper --verbose \
-                --extract $destination/Lib/site-packages/win32/perfmondata.dll.embedded \
-                $destination/Lib/site-packages/win32/perfmondata.dll
-            $manifest_wiper --verbose \
-                --extract $destination/Lib/site-packages/pywin32_system32/pythoncomloader27.dll.embedded \
-                $destination/Lib/site-packages/pywin32_system32/pythoncomloader27.dll
-
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/Lib/site-packages/win32/pythonservice.exe.embedded > $destination/Lib/site-packages/win32/pythonservice.exe.manifest
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/Lib/site-packages/win32/perfmondata.dll.embedded > $destination/Lib/site-packages/win32/perfmondata.dll.manifest
-            execute rm -f --verbose $desination/Lib/site-packages/win32/*.embedded
-            execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/Lib/site-packages/pywin32_system32/pythoncomloader27.dll.embedded > $destination/Lib/site-packages/pywin32_system32/pythoncomloader27.dll.manifest
-            execute rm -f --verbose $desination/Lib/site-packages/pywin32_system32/*.embedded
-
-            echo "Copy Python runtime to pyWin32 package"
-            execute cp $destination/*CRT.manifest $destination/Lib/site-packages/win32/
-            execute cp $destination/python27.dll.manifest $destination/Lib/site-packages/win32/
-            execute cp $destination/python27.dll $destination/Lib/site-packages/win32/
-            execute cp $destination/msvc?90.dll $destination/Lib/site-packages/win32/
-            execute cp $destination/Lib/site-packages/pywin32_system32/*.dll $destination/Lib/site-packages/win32/
+            wipe_manifest $destination/python.exe
+            wipe_manifest $destination/pythonw.exe
+            wipe_manifest $destination/python27.dll
 
             # Remove Python MSI installer.
             echo "Removing: $destination/python-installer.msi"

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -5,13 +5,6 @@
 # Import shared code.
 . ./functions.sh
 
-PIP_INSTALLABLES_WIN="\
-    pypiwin32==219 \
-    pycrypto==2.6.1 \
-    cryptography==1.3 \
-    pyOpenSSL==16.0.0 \
-    "
-
 chevahbs_configure() {
     CONFIG_ARGS="--disable-shared"
 
@@ -151,12 +144,8 @@ chevahbs_install() {
             execute sed -e 's|version="9.0.21022.8"|version="9.00.30729.6161"|' -e 's|publicKeyToken="1fc8b3b9a1e18e3b"||' < $destination/python27.dll.embedded > $destination/python27.dll.manifest
             execute rm -f --verbose $destination/*.embedded
 
-            echo "Installing pip + binary modules"
+            echo "Installing pip"
             execute $destination/python $get_pip $PIP_ARGS
-            execute $destination/python -m pip \
-                install $PIP_ARGS $PIP_INSTALLABLES_WIN
-            # Remove pip.
-            execute $destination/python -m pip uninstall -y pip
 
             echo "Patching pyWin32 manifests to use our redistributable version"
             $manifest_wiper --verbose \
@@ -195,13 +184,6 @@ chevahbs_install() {
             ;;
         *)
             execute $MAKE install DESTDIR=$INSTALL_FOLDER
-            ;;
-    esac
-
-    case $OS in
-        # For now we only install PIP on ArchLinux
-        "archlinux")
-            execute $INSTALL_FOLDER/bin/python ../../python-modules/get-pip.py $PIP_ARGS
             ;;
     esac
 }


### PR DESCRIPTION
Scope
=====

Update build system to create package for ubuntu 16.04

Changes
========

Since pyopenssl 0.13 no longer works with OpenSSL available on Ubuntu 16.04  i have updated the build system to the one similar to Arch.

In the future all builds should use that system.

I have refactored a bit the windows part to re-use the common process.

src/python/chevahbs no longer installs pip, but just make sure that we have a minimal python.

I have also enable new build system for rhel 5,6,7 and sles 11,12 and generic linux, raspbian7, openbsd and solaris11

aix, freebsd and solaris10 are broken ... but since solaris 10 has a very old openssl I am not sure if we can upgrade it.

As a drive by I have added the github PR template.

How to test
=========

reviewers: @brunogola @dumol @alibotean 

check that changes make sense

thanks!
 