### PR TITLE
[#3405] Update for OpenBSD 5.9.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -513,10 +513,10 @@ detect_os() {
         ARCH=$(uname -m)
 
         os_version_raw=$(uname -r)
-        check_os_version "OpenBSD" 5.8 "$os_version_raw" os_version_chevah
+        check_os_version "OpenBSD" 5.9 "$os_version_raw" os_version_chevah
 
-        # For now, no matter the actual OpenBSD version returned, we use '58'.
-        OS="openbsd58"
+        # For now, no matter the actual OpenBSD version returned, we use '59'.
+        OS="openbsd59"
 
     else
         echo 'Unsupported operating system:' $OS

--- a/paver.sh
+++ b/paver.sh
@@ -463,7 +463,7 @@ detect_os() {
                 OS="sles${os_version_chevah}"
             fi
         elif [ -f /etc/arch-release ]; then
-            # ArchLinux is a rolling distro, no version info available
+            # ArchLinux is a rolling distro, no version info available.
             OS="archlinux"
         elif [ -f /etc/rpi-issue ]; then
             # Raspbian is a special case, a Debian unofficial derivative.
@@ -495,7 +495,7 @@ detect_os() {
         ARCH=$(uname -m)
 
         os_version_raw=$(sw_vers -productVersion)
-        check_os_version "Mac OS X" 10.4 "$os_version_raw" os_version_chevah
+        check_os_version "Mac OS X" 10.8 "$os_version_raw" os_version_chevah
 
         # For now, no matter the actual OS X version returned, we use '108'.
         OS="osx108"


### PR DESCRIPTION
Scope
=====

Update `python-package` for OpenBSD 5.9.


Changes
=======

Pulled all changes from master, where the problem with newest OpenSSL versions was solved for Arch Linux and Ubuntu 16.04.
Updated the hardcoded OpenBSD version from 5.8 to 5.9.

**Drive-by fixes**:
  * update `paver.sh` from `salt-master` (a minor fix for OS X and an improved comment).

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the automated tests through `paver_review`.