### PR TITLE
[#3468] Add support for SLES 10.

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,9 @@ Rebuild Python from your home
 If a buildbot is already active for the platform, you can use
 `paver test_remote` to rebuild Python distribution on that system,
 
+You will have to wait about 10 minutes after publishing so that the packages
+will reach the public server.
+
 Do a testing build (files go in http://binary.chevah.com/testing/python/)::
 
     paver test_remote NAME_OF_BUILDER

--- a/chevah_build
+++ b/chevah_build
@@ -78,6 +78,9 @@ SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
 if [ $OS = 'sles10' ]; then
     SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
 fi
+if [ $OS = 'rhel5' ]; then
+    RHEL_PACKAGES="$RHEL_PACKAGES automake15"
+fi
 
 # List of OS packages requested to be installed by this script.
 INSTALLED_PACKAGES=''

--- a/chevah_build
+++ b/chevah_build
@@ -8,22 +8,6 @@
 # publish_staging
 #
 
-# List of OS packages required for building Python.
-COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
-DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
-RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
-SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
-
-# List of OS packages requested to be installed by this script.
-INSTALLED_PACKAGES=''
-# For now, we don't install anything on OS X, Solaris, AIX, and
-# unsupported Linux distros. The build requires a C compiler, GNU make, m4,
-# the header files for OpenSSL and zlib, and (optionally) texinfo.
-# To build libedit for the readline module, we need the headers of
-# a curses library, automake and libtool.
-# On platforms with a choice of C compilers, you may choose among the
-# available compilers by setting CC and CXX further in this script.
-
 LIBFFI_VERSION=3.2.1
 GMP_VERSION=6.0.0
 LIBEDIT_VERSION=20150325-3.1
@@ -85,6 +69,25 @@ PYTHON_VERSION=`cut -d' ' -f 2 DEFAULT_VALUES`
 OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 TIMESTAMP=`date +'%Y%m%d'`
+
+# List of OS packages required for building Python.
+COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
+DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
+RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
+SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
+if [ $OS = 'sles10' ]; then
+    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
+fi
+
+# List of OS packages requested to be installed by this script.
+INSTALLED_PACKAGES=''
+# For now, we don't install anything on OS X, Solaris, AIX, and
+# unsupported Linux distros. The build requires a C compiler, GNU make, m4,
+# the header files for OpenSSL and zlib, and (optionally) texinfo.
+# To build libedit for the readline module, we need the headers of
+# a curses library, automake and libtool.
+# On platforms with a choice of C compilers, you may choose among the
+# available compilers by setting CC and CXX further in this script.
 
 # In Solaris and AIX we use $ARCH to choose if we build a 32bit or 64bit
 # package. This way we are able to force a 32bit build on a 64bit machine,
@@ -207,6 +210,8 @@ case $OS in
         ;;
     sles10)
         BUILD_CFFI="no"
+        PIP_LIBRARIES=""
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     windows*)
         # On Windows, python executable is installed at a different path.
@@ -274,9 +279,6 @@ install_dependencies() {
     if [ -n "$packages" ]; then
         echo "Checking for packages to be installed..."
         for package in $packages ; do
-            if [ $OS = 'sles10' -a $package = 'libopenssl-devel' ]; then
-                package='openssl-devel'
-            fi
             echo "Checking if $package is installed..."
             $check_command $package
             if [ $? -ne 0 ]; then

--- a/chevah_build
+++ b/chevah_build
@@ -205,6 +205,9 @@ case $OS in
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
+    sles10)
+        BUILD_CFFI="no"
+        ;;
     windows*)
         # On Windows, python executable is installed at a different path.
         LOCAL_PYTHON_BINARY=./$LOCAL_PYTHON_BINARY_DIST/lib/python
@@ -271,6 +274,9 @@ install_dependencies() {
     if [ -n "$packages" ]; then
         echo "Checking for packages to be installed..."
         for package in $packages ; do
+            if [ $OS = 'sles10' -a $package = 'libopenssl-devel' ]; then
+                package='openssl-devel'
+            fi
             echo "Checking if $package is installed..."
             $check_command $package
             if [ $? -ne 0 ]; then
@@ -384,6 +390,9 @@ command_build() {
     # libs (ncurses, ncursesw, tinfo, others?), and the result is not portable.
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
+        sles10)
+            true
+            ;;
         ubuntu*|raspbian*|rhel*|sles*|solaris*|archlinux)
             build 'libedit' "libedit-$LIBEDIT_VERSION" ${PYTHON_BUILD_FOLDER}
             cp -r $INSTALL_FOLDER/tmp/libedit/{editline/,*.h} \

--- a/chevah_build
+++ b/chevah_build
@@ -393,6 +393,8 @@ command_build() {
     # $CPPFLAGS and $LDFLAGS already point to these 'include' and 'lib' dirs.
     case $OS in
         sles10)
+            # Don't build libedit on SLES 10 as this is an old platform and is
+            # ok if it runs with limited support.
             true
             ;;
         ubuntu*|raspbian*|rhel*|sles*|solaris*|archlinux)

--- a/paver.sh
+++ b/paver.sh
@@ -458,7 +458,7 @@ detect_os() {
             if [ $(head -n1 /etc/SuSE-release | cut -d' ' -f1) = 'SUSE' ]; then
                 os_version_raw=$(\
                     grep VERSION /etc/SuSE-release | cut -d' ' -f3)
-                check_os_version "SUSE Linux Enterprise Server" 11 \
+                check_os_version "SUSE Linux Enterprise Server" 10 \
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
             fi


### PR DESCRIPTION
Scope
=====

This add support for building the python package on SLES 10


Changes
=======

SLES 10 has an old openssl 0.9.8 so we build using the old pyopenssl 0.13.0

libedit is disabled on sles10


How to try and test the changes
===============================

reviewers: @dumol 

check that changes are ok.

I have pushed a first version in production and I will test this with compat and chevah.server

