### PR TITLE
[#3742] OpenBSD 6.0 support.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -514,9 +514,7 @@ detect_os() {
 
         os_version_raw=$(uname -r)
         check_os_version "OpenBSD" 5.9 "$os_version_raw" os_version_chevah
-
-        # For now, no matter the actual OpenBSD version returned, we use '59'.
-        OS="openbsd59"
+        OS="openbsd${os_version_chevah}"
 
     else
         echo 'Unsupported operating system:' $OS


### PR DESCRIPTION
Scope
=====

No previous support for OpenBSD 6.0, the latest stable version.


Changes
=======

Stop hard-coding a specific version of OpenBSD, as the stable version changes every 6 months. 
It's enough to check for the oldest supported version, nowadays 5.9 and to have the corresponding Python packages available at binary.chevah.com


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the change.
Run the automated tests.
