### PR TITLE
[#3732] Add Solaris 10 U3 detection to paver

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -422,7 +422,21 @@ detect_os() {
         os_version_raw=$(uname -r | cut -d'.' -f2)
         check_os_version Solaris 10 "$os_version_raw" os_version_chevah
 
-        OS="solaris${os_version_chevah}"
+        # Solaris 10 updated the libc version between other minor updates,
+        # so to keep compatibilty with the older libc version,
+        # we have a dedicated solaris10u3 (or older) version check.
+        # For newer Solaris 10 versions, we use solaris10.
+        if [ $os_version_raw == 10 ]; then
+            solaris10_release_year=$(grep 10 /etc/release | \
+                cut -d'/' -f2 | cut -d' ' -f1)
+            if [ $solaris10_release_year -le 6 ]; then
+                OS="solaris10u3"
+            else
+                OS="solaris${os_version_chevah}"
+            fi
+        else
+            OS="solaris${os_version_chevah}"
+        fi
 
     elif [ "${OS}" = "aix" ]; then
 


### PR DESCRIPTION
Scope
=====

Implement Solaris 10 U3 detection on paver.sh


Changes
=======

Added a variable to store the exact Solaris release year, and conditions that checks if the release is 'solaris10u3'. In that case, it saves that on the OS variable.


How to try and test the changes
===============================

reviewers: @adiroiban @dumol 
You can check by running paver.sh detect_os on a Solaris10u3 system and checking the DEFAULT_VALUES file