### PR TITLE
[#3777] Only do the ctypes windows hack on windows.

### DIFF
--- a/src/python/Python-2.7.10/Lib/ctypes/__init__.py
+++ b/src/python/Python-2.7.10/Lib/ctypes/__init__.py
@@ -272,11 +272,13 @@ def _reset_cache():
     # _SimpleCData.c_char_p_from_param
     POINTER(c_char).from_param = c_char_p.from_param
     _pointer_type_cache[None] = c_void_p
-    # XXX for whatever reasons, creating the first instance of a callback
-    # function is needed for the unittests on Win64 to succeed.  This MAY
-    # be a compiler bug, since the problem occurs only when _ctypes is
-    # compiled with the MS SDK compiler.  Or an uninitialized variable?
-    CFUNCTYPE(c_int)(lambda: None)
+
+    if _os.name in ("nt", "ce"):
+        # XXX for whatever reasons, creating the first instance of a callback
+        # function is needed for the unittests on Win64 to succeed.  This MAY
+        # be a compiler bug, since the problem occurs only when _ctypes is
+        # compiled with the MS SDK compiler.  Or an uninitialized variable?
+        CFUNCTYPE(c_int)(lambda: None)
 
 try:
     from _ctypes import set_conversion_mode


### PR DESCRIPTION
Scope
=====

See 

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=781578

and

https://bugzilla.redhat.com/show_bug.cgi?id=674369


Changes
=======

I went for executing that code only on Windows... since it a windows only hack.


How to try and test the changes
===============================

reviewers: @alibotean 

check that changes make sense.