### PR TITLE
[#3810] Fix the test for checking dependencies.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -89,7 +89,7 @@ def get_allowed_deps():
                 'libtinfo.so.5',
                 ])
         else:
-            # Debian 7 x64 aka linux-x64 needs this for some reason.
+            # Debian 7 x64 (aka linux-x64) needs this for cffi.
             allowed_deps.extend([
                 'libgcc_s.so.1',
                 ])
@@ -181,7 +181,7 @@ def get_allowed_deps():
             'libz.1.dylib',
             ]
     elif platform_system == 'freebsd':
-        # This is the list of deps for FreeBSD 10.x, sans versions.
+        # This is the list of specific deps for FreeBSD 10.x, with paths.
         allowed_deps = [
             '/lib/libc.so.7',
             '/lib/libcrypt.so.5',
@@ -221,7 +221,7 @@ def get_actual_deps(script_helper):
         libs_deps = []
         for line in raw_deps:
             if line.startswith('./'):
-                # In some OS'es (AIX, FreeBSD, OS X), the output includes
+                # In some OS'es (AIX, OS X, the BSDs), the output includes
                 # the examined binaries, and those lines start with "./".
                 # It's safe to ignore them because they point to paths in
                 # the current hierarchy of directories.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -441,7 +441,7 @@ def main():
             sys.stderr.write('"readline" missing.\n')
             exit_code = 13
 
-        exit_code = test_dependencies() | exit_code
+    exit_code = test_dependencies() | exit_code
 
     sys.exit(exit_code)
 

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -19,8 +19,7 @@ def get_allowed_deps():
     """
     allowed_deps = []
     if platform_system == 'linux':
-        # The minimal list of deps for Linux: glibc, openssl, zlib,
-        # and, for readline support through libedit, a curses library.
+        # The minimal list of deps for Linux: glibc, openssl and zlib.
         allowed_deps = [
             'ld-linux',
             'libc.so',
@@ -28,7 +27,6 @@ def get_allowed_deps():
             'libcrypto.so',
             'libdl.so',
             'libm.so',
-            'libncursesw.so',
             'libnsl.so',
             'libpthread.so',
             'libssl.so',
@@ -45,6 +43,7 @@ def get_allowed_deps():
                 'libgssapi_krb5.so.2',
                 'libk5crypto.so.3',
                 'libkrb5.so.3',
+                'libncursesw.so.5',
                 'libresolv.so.2',
                 ])
             rhel_version = int(chevah_os[4:])
@@ -68,7 +67,11 @@ def get_allowed_deps():
         elif ('sles' in chevah_os):
             test_for_readline = True
             sles_version = int(chevah_os[4:])
-            if sles_version == 12:
+            if sles_version >= 11:
+                allowed_deps.extend([
+                    'libncursesw.so.5',
+                    ])
+            if sles_version >= 12:
                 allowed_deps.extend([
                     'libtinfo.so.5',
                     ])
@@ -84,6 +87,11 @@ def get_allowed_deps():
                 'libgcc_s.so.1',
                 'libncurses.so.5',
                 'libtinfo.so.5',
+                ])
+        else:
+            # Debian 7 x64 aka linux-x64 needs this for some reason.
+            allowed_deps.extend([
+                'libgcc_s.so.1',
                 ])
     elif platform_system == 'aix':
         # This is the standard list of deps for AIX 5.3. Some of the links

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -227,18 +227,13 @@ def get_actual_deps(script_helper):
                 # examined files and the needed libs are in the 7th colon, which
                 # also includes a colon name, of which we'll get rid below.
                 dep = line.split()[6]
-                # The "Name" colon header and the names of the examined binaries
-                # are purged here. Some more strings start with './'.
-                strings_to_ignore = [ 'Name', os.getcwd(), './' ]
-                for single_string_to_ignore in strings_to_ignore:
-                    if dep.startswith(single_string_to_ignore):
-                        dep = None
-                        break
+                strings_to_ignore = ( 'Name', os.getcwd(), './', )
+                if dep.startswith(strings_to_ignore):
+                    continue
             else:
                 # Usually, the first field in each line is the needed file name.
                 dep = line.split()[0]
-            if dep:
-                libs_deps.append(dep)
+            libs_deps.append(dep)
     return list(set(libs_deps))
 
 


### PR DESCRIPTION
Scope
=====

The deps check in the test phase only works for OS'es where we check for `readline`, as the code was moved to a dedicated function and the call for the new function is indented too much. More at ​https://github.com/chevah/python-package/commit/d502092fb883bbb150f6eef145e9e752499ccf94#diff-d928fcacc543beb698c192bc0a02e064L349

Changes
=======

Unindented the call to the function that checks the deps, so that it is always called.
Added sanctioned deps for FreeBSD.
Tuned the deps for Linux in accordance to latest developments.

Drive-by test:
  * improved the deps check in OpenBSD to account for any unusual deps not in `/usr`, eg. `/opt` or `/home`.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests.