### PR TITLE
[#3827] Clean temporary directory on OSX.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -98,12 +98,12 @@ clean_build() {
     fi
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
-    rm -rf /tmp/pip*
-
     # On the OSX build server tmp is in $TMPDIR
-    # check if TMPDIR is set before trying to clean it.
     if [ ! -z "${TMPDIR-}" ]; then
+        # check if TMPDIR is set before trying to clean it.
         rm -rf ${TMPDIR}/pip*
+    else
+        rm -rf /tmp/pip*
     fi
 }
 

--- a/paver.sh
+++ b/paver.sh
@@ -99,6 +99,12 @@ clean_build() {
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
     rm -rf /tmp/pip*
+
+    # On the OSX build server tmp is in $TMPDIR
+    # check if TMPDIR is set before trying to clean it.
+    if [ ! -z "${TMPDIR-}" ]; then
+        rm -rf ${TMPDIR}/pip*
+    fi
 }
 
 


### PR DESCRIPTION
Scope
=====

On OSX the temporary pip directory was not removed if pip failed as it is not under /tmp.


Changes
=======

Add code to clean the folder under ${TMPDIR}.


How to try and test the changes
===============================

reviewers: @adiroiban @dumol 

Please check if changes make sense.
