### PR TITLE
[#3834] Check for the multiprocessing module.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -413,6 +413,13 @@ def main():
         sys.stderr.write('"ctypes.utils - find_library" missing.\n')
         exit_code = 9
 
+    try:
+        import multiprocessing
+        multiprocessing.current_process()
+    except:
+        sys.stderr.write('"multiprocessing" missing.\n')
+        exit_code = 11
+
     # Windows specific modules.
     if os.name == 'nt':
         try:

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -292,20 +292,20 @@ def test_dependencies():
     if not allowed_deps:
         sys.stderr.write('Got no allowed deps. Please check if {0} is a '
             'supported operating system.\n'.format(platform.system()))
-        return 13
+        return 113
 
     actual_deps = get_actual_deps(script_helper)
     if not actual_deps:
         sys.stderr.write('Got no deps for the new binaries. Please check '
             'the "{0}" script in the "build/" dir.\n'.format(script_helper))
-        return 14
+        return 114
 
     unwanted_deps = get_unwanted_deps(allowed_deps, actual_deps)
     if unwanted_deps:
         sys.stderr.write('Got unwanted deps:\n')
         for single_dep_to_print in unwanted_deps:
             sys.stderr.write('\t{0}\n'.format(single_dep_to_print))
-        return 15
+        return 115
 
     return 0
 
@@ -481,7 +481,7 @@ def main():
             readline.get_history_length()
         except:
             sys.stderr.write('"readline" missing.\n')
-            exit_code = 13
+            exit_code = 12
 
     exit_code = test_dependencies() | exit_code
 


### PR DESCRIPTION
Scope
=====

Solaris 10 x86 is missing the multiprocessing module.


Changes
=======

Added a new test to check for the _multiprocessing_ module when testing the `python` binary.
Downgraded the compiler from 12.5 to 12.4 on the Solaris x86, so that we don't have to updated the POSIX-related definition in `multiprocessing.h` to make the needed extra functions available through the Sun Studio compiler. Note that on our current SPARC Solaris 10 server the 12.5 version doesn't work because of a hardware incompatibility.

**Drive-by changes**:
  * incremented duplicated error code when testing the `python` binary
  * improved on the error code scheme when testing the `python` binary.

How to try and test the changes
===============================

reviewers: @adiroiban @brunogola 

Please review changes
Check for missing _multiprocessing_ module with the old code in the module, eg. https://chevah.com/buildbot/builders/python-package-solaris-10/builds/120/steps/test/logs/stdio
Run the tests, including the new one of the _multiprocessing_ module on all the review targets, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/25