### PR TITLE
[#3966] Support for OpenSSL 1.0.x in HP-UX.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -218,6 +218,9 @@ case $OS in
         export MAKE="gmake"
         export BUILD_ZLIB="yes"
         export BUILD_LIBEDIT="no"
+        export BUILD_CFFI="no"
+        PIP_LIBRARIES=""
+        EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     osx*)
         # The extra params needed to set the minimum target version to 10.8

--- a/python-modules/cffi-1.5.2/setup.py
+++ b/python-modules/cffi-1.5.2/setup.py
@@ -1,6 +1,7 @@
 import sys, os
 import subprocess
 import errno
+import _ssl
 
 
 sources = ['c/_cffi_backend.c']

--- a/python-modules/cffi-1.5.2/setup.py
+++ b/python-modules/cffi-1.5.2/setup.py
@@ -1,7 +1,7 @@
 import sys, os
 import subprocess
 import errno
-import _ssl
+import _ssl # Needed in HP-UX, unexpectedly.
 
 
 sources = ['c/_cffi_backend.c']

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -165,13 +165,13 @@ def get_allowed_deps():
         # Specific deps for HP-UX 11.31, with full path.
         allowed_deps = [
             '/usr/lib/hpux32/libc.so.1',
-            '/usr/lib/hpux32/libcrypto.so.1',
+            '/usr/lib/hpux32/libcrypto.so.1.0.0',
             '/usr/lib/hpux32/libdl.so.1',
             '/usr/lib/hpux32/libm.so.1',
             '/usr/lib/hpux32/libnsl.so.1',
             '/usr/lib/hpux32/libpthread.so.1',
             '/usr/lib/hpux32/librt.so.1',
-            '/usr/lib/hpux32/libssl.so.1',
+            '/usr/lib/hpux32/libssl.so.1.0.0',
             '/usr/lib/hpux32/libxnet.so.1',
             '/usr/lib/hpux32/libxti.so.1',
             ]

--- a/python-modules/get-pip.py
+++ b/python-modules/get-pip.py
@@ -25,6 +25,7 @@ import pkgutil
 import shutil
 import sys
 import struct
+import _ssl
 import tempfile
 
 # Useful for very coarse version differentiation.

--- a/python-modules/get-pip.py
+++ b/python-modules/get-pip.py
@@ -25,7 +25,7 @@ import pkgutil
 import shutil
 import sys
 import struct
-import _ssl
+import _ssl # Needed in HP-UX, unexpectedly.
 import tempfile
 
 # Useful for very coarse version differentiation.


### PR DESCRIPTION
Scope
=====

As noted in Trac's ticket #2703, the HP-UX initial support was done for OpenSSL 0.9.8, but only 1.0.2 is currently supported in HP-UX, according to https://h20392.www2.hpe.com/portal/swdepot/displayProductInfo.do?productNumber=OPENSSL11I.


Changes
=======

Added an explicit import for `_ssl` to avoid errors with `pip` and `cffi` when building against OpenSSL 1.0.2.
Do not build CFFI on HP-UX for now.
Updated OpenSSL deps to 1.0.x for the test phase.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/44