### PR TITLE
[#3962] Parallel builds.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -307,16 +307,14 @@ fi
 # Parallel builds where applicable.
 case "$ARCH" in
     sparc*)
-        # Best for Laslea (~60% faster than -j1).
-        MAKE="$MAKE -j2"
-        if [ "$OS" == "solaris11" ]; then
-            # Best for Jacu (~100% faster than -j1).
-            MAKE="$MAKE -j5"
-        fi
+        CPUS=$(/usr/sbin/psrinfo -p)
+        let JOBS=2*$CPUS
+        MAKE="$MAKE -j${JOBS}"
         ;;
     armv7l*)
-        # Best for Zmeur2 (~55% faster than -j1).
-        MAKE="$MAKE -j4"
+        CPUS=$(nproc)
+        let JOBS=$CPUS
+        MAKE="$MAKE -j${JOBS}"
 esac
 
 #

--- a/chevah_build
+++ b/chevah_build
@@ -228,6 +228,7 @@ case $OS in
         # when compiling Python with -DNDEBUG, the recommended default.
         export CC="/opt/aCC/bin/cc -w"
         export CXX="/opt/aCC/bin/aCC"
+        # Native make is needed for parallel builds.
         export MAKE="make -P"
         export BUILD_ZLIB="yes"
         export BUILD_LIBEDIT="no"

--- a/chevah_build
+++ b/chevah_build
@@ -318,7 +318,7 @@ case "$ARCH" in
         ;;
 esac
 if [ "${OS%hpux*}" = "" ]; then
-    export PARALLEL="$CPUS"
+    export PARALLEL="$JOBS"
 else
     export MAKE="$MAKE -j${JOBS}"
 fi

--- a/chevah_build
+++ b/chevah_build
@@ -228,7 +228,7 @@ case $OS in
         # when compiling Python with -DNDEBUG, the recommended default.
         export CC="/opt/aCC/bin/cc -w"
         export CXX="/opt/aCC/bin/aCC"
-        export MAKE="gmake"
+        export MAKE="make -P"
         export BUILD_ZLIB="yes"
         export BUILD_LIBEDIT="no"
         export BUILD_CFFI="no"
@@ -305,17 +305,23 @@ elif [ "$CC" = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
 fi
 
 # Parallel builds where applicable.
+get_number_of_cpus
+JOBS=1
 case "$ARCH" in
     sparc*)
-        CPUS=$(/usr/sbin/psrinfo -p)
-        let JOBS=2*$CPUS
-        MAKE="$MAKE -j${JOBS}"
+        # Twice the number of physical CPUs is optimal on SPARC machines.
+        let JOBS=2*CPUS
         ;;
-    armv7l*)
-        CPUS=$(nproc)
-        let JOBS=$CPUS
-        MAKE="$MAKE -j${JOBS}"
+    *)
+        # On other virtual and physical machines this is close to optimum.
+        let JOBS=CPUS
+        ;;
 esac
+if [ "${OS%hpux*}" = "" ]; then
+    export PARALLEL="$CPUS"
+else
+    export MAKE="$MAKE -j${JOBS}"
+fi
 
 #
 # Install OS package required to build Python.

--- a/chevah_build
+++ b/chevah_build
@@ -291,6 +291,21 @@ elif [ "$CC" = 'gcc' -a ${ARCH%%64} != "$ARCH" ]; then
     export CFLAGS="${CFLAGS} -fPIC"
 fi
 
+# Parallel builds where applicable.
+case "$ARCH" in
+    sparc*)
+        # Best for Laslea (~60% faster than -j1).
+        MAKE="$MAKE -j2"
+        if [ "$OS" == "solaris11" ]; then
+            # Best for Jacu (~100% faster than -j1).
+            MAKE="$MAKE -j5"
+        fi
+        ;;
+    armv7l*)
+        # Best for Zmeur2 (~55% faster than -j1).
+        MAKE="$MAKE -j4"
+esac
+
 #
 # Install OS package required to build Python.
 #

--- a/functions.sh
+++ b/functions.sh
@@ -249,15 +249,15 @@ wipe_manifest() {
 get_number_of_cpus() {
     case "$OS" in
         aix*)
-            # This works in an AIX 5.3 WPAR too.
+            # This works in an AIX 5.3 vWPAR too.
             CPUS=$(lparstat -i | grep ^"Maximum Physical CPUs" | cut -d\: -f2)
             ;;
         solaris*)
-            # Only physical processor count. Tested on SPARC, AMD64 and X86.
+            # Only count physical processors. Tested on SPARC, AMD64 and X86.
             CPUS=$(/usr/sbin/psrinfo -p)
             ;;
         hpux*)
-            # Only physical processor count. Tested on Itanium.
+            # Only count physical processors. Tested on Itanium.
             CPUS=$(machinfo | grep proc | grep core | awk '{print $1}')
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)
@@ -265,6 +265,7 @@ get_number_of_cpus() {
             ;;
         *)
             # Only Linux distros should be left.
+            # Don't use lscpu/nproc, as they are not present on older distros.
             CPUS=$(getconf _NPROCESSORS_ONLN)
             ;;
     esac

--- a/functions.sh
+++ b/functions.sh
@@ -245,3 +245,27 @@ wipe_manifest() {
     execute rm -f --verbose ${source}.embedded
 
 }
+
+get_number_of_cpus() {
+    case "$OS" in
+        aix*)
+            # This works in an AIX 5.3 WPAR too.
+            CPUS=$(lparstat -i | grep ^"Maximum Physical CPUs" | cut -d\: -f2)
+            ;;
+        solaris*)
+            # Only physical processor count. Tested on SPARC, AMD64 and X86.
+            CPUS=$(/usr/sbin/psrinfo -p)
+            ;;
+        hpux*)
+            # Only physical processor count. Tested on Itanium.
+            CPUS=$(machinfo | grep proc | grep core | awk '{print $1}')
+            ;;
+        osx*|macos*|freebsd*|openbsd*|netbsd*)
+            CPUS=$(sysctl -n hw.ncpu)
+            ;;
+        *)
+            # Only Linux distros should be left.
+            CPUS=$(getconf _NPROCESSORS_ONLN)
+            ;;
+    esac
+}

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -14,6 +14,7 @@ chevahbs_configure() {
             # On some exotic platforms libffi only compiles with GCC.
             CC="gcc"
             CXX="g++"
+            MAKE="gmake"
             unset CFLAGS
             ;;
     esac

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -33,9 +33,13 @@ chevahbs_patch() {
             execute patch < solaris10_paths.patch
             ;;
         hpux*)
+            # Our patch to please the native make, needed for parallel builds.
+            echo "Applying hpux_nativemake.patch:"
+            execute patch < hpux_nativemake.patch
             # Our patch to use -fPIC extra argument for linking only with GCC.
             echo "Applying hpux_fpic.patch:"
             execute patch < hpux_fpic.patch
+            # Our patch to import _ssl for working crypto.
             echo "Applying hpux_site.patch:"
             execute patch -p0 < hpux_site.patch
             # The second patch from https://bugs.python.org/issue18777.
@@ -104,8 +108,6 @@ chevahbs_configure() {
             fi
             ;;
         hpux*)
-            # Native make fails and gmake only works serially.
-            MAKE="gmake"
             LDFLAGS="${LDFLAGS} -lxnet"
             CONFIG_ARGS="${CONFIG_ARGS} \
                 --with-system-ffi \

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -104,6 +104,8 @@ chevahbs_configure() {
             fi
             ;;
         hpux*)
+            # Native make fails and gmake only works serially.
+            MAKE="gmake"
             LDFLAGS="${LDFLAGS} -lxnet"
             CONFIG_ARGS="${CONFIG_ARGS} \
                 --with-system-ffi \

--- a/src/python/hpux_nativemake.patch
+++ b/src/python/hpux_nativemake.patch
@@ -1,0 +1,12 @@
+diff -ur Makefile.pre.in Makefile.pre.in
+--- Makefile.pre.in
++++ Makefile.pre.in
+@@ -314,7 +314,7 @@
+ 
+ OPCODETARGETS_H= \
+ 		$(srcdir)/Python/opcode_targets.h
+-		
++
+ OPCODETARGETGEN= \
+ 		$(srcdir)/Python/makeopcodetargets.py
+ 


### PR DESCRIPTION
Scope
=====

Speed up building python-package.


Changes
=======

With `-j` for GNU `make` where supported .
With `PARALLEL` and the native `make` in HP-UX (where I had to keep using `gmake` for libffi).

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/50
Compare the running times, especially for dedicated, bare metal machines, which were also the slowest ones. Per review test, the above one took ~58min, while the previous serial one took ~84min.

