### PR TITLE
[#4019] Fix deps for Solaris 11 x64.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -154,6 +154,7 @@ def get_allowed_deps():
                 else:
                     allowed_deps.extend([
                         '/lib/64/libelf.so.1',
+                        '/usr/lib/amd64/libc.so.1',
                         ])
         else:
             # Full deps for Solaris 10u3 x86 (and possibly other 32bit builds).


### PR DESCRIPTION
Scope
=====

Deps test on Solaris 11 x64 fails with:
```
Got unwanted deps:
	/usr/lib/amd64/libc.so.1
```


Changes
=======

Added missing dep.
This issue was introduced by #63, where `test group-all` failed for Solaris 11 x64, but nobody noticed.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the change.
Run `test_review`, eg.: https://chevah.com/buildbot/builders/python-package-gk-review/builds/45