### PR TITLE
[#4024] Use a fixed version of pip and setuptools

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,8 @@ Here are the steps used by Buildbot:
 * ./chevah_build test
 * upload to binary dist publishing website.
 
+Use `./chevah_build help` to discover the available commands.
+
 
 Rebuild Python from your home
 ---------------------------

--- a/chevah_build
+++ b/chevah_build
@@ -700,6 +700,18 @@ command_test() {
 }
 
 
+#
+# Test the newly created Python binary dist.
+#
+help_text_test_compat=\
+"Run a full test for the chevah/compat master."
+command_test_compat() {
+    # For now it does nothing.
+    # Here since the buildmaster was updated.
+    # Will be overwritten in #4020.
+}
+
+
 help_text_publish_python=\
 "Upload Python binaries for current OS."
 command_publish_python() {

--- a/chevah_build
+++ b/chevah_build
@@ -21,8 +21,8 @@ SQLITE_VERSION="3.17.0"
 PYSQLITE_VERSION="2.6.3"
 # These are used by the patched get-pip.py.
 # PIP_VERSION is already used by get-pip for something else.
-export CHEVAH_PIP_VERSION=7.1.2
-export SETUPTOOLS_VERSION=20.3.1
+export CHEVAH_PIP_VERSION="7.1.2"
+SETUPTOOLS_VERSION="20.3.1"
 
 # Git revision to inject into Python's sys.version string through chevahbs.
 PYTHON_PACKAGE_VERSION=$(git rev-parse --short HEAD)

--- a/chevah_build
+++ b/chevah_build
@@ -19,6 +19,10 @@ LIBEDIT_VERSION="20160903-3.1"
 GMP_VERSION="6.1.2"
 SQLITE_VERSION="3.17.0"
 PYSQLITE_VERSION="2.6.3"
+# These are used by the patched get-pip.py.
+# PIP_VERSION is already used by get-pip for something else.
+export CHEVAH_PIP_VERSION=7.1.2
+export SETUPTOOLS_VERSION=20.3.1
 
 # Git revision to inject into Python's sys.version string through chevahbs.
 PYTHON_PACKAGE_VERSION=$(git rev-parse --short HEAD)
@@ -540,6 +544,8 @@ command_build_sqlite() {
 command_build_python_extra_libraries() {
 
     # Install the latest PIP and setuptools.
+    # But first path it to get the exact version.
+    execute patch -p0 < python-modules/get-pip-pin.patch
     execute $PYTHON_BIN python-modules/get-pip.py $PIP_ARGS
 
     # pycparser is installed first as setup_requires is ugly.

--- a/chevah_build
+++ b/chevah_build
@@ -23,7 +23,7 @@ PYSQLITE_VERSION="2.6.3"
 # PIP_VERSION is already used by get-pip for something else.
 # For now, we can't use version 8 of pip as our PyPi server does not support
 # simplified names.
-export CHEVAH_PIP_VERSION="7.1.2"
+CHEVAH_PIP_VERSION="7.1.2"
 SETUPTOOLS_VERSION="20.3.1"
 
 # Git revision to inject into Python's sys.version string through chevahbs.
@@ -37,6 +37,7 @@ PYCPARSER_VERSION="2.14"
 
 # Export the variables needed by the chevahbs scripts and the test phase.
 export PYTHON_BUILD_VERSION PYTHON_PACKAGE_VERSION REDISTRIBUTABLE_VERSION
+export CHEVAH_PIP_VERSION
 export BUILD_ZLIB="no"
 export BUILD_LIBEDIT="yes"
 export BUILD_GMP="yes"
@@ -546,8 +547,8 @@ command_build_sqlite() {
 command_build_python_extra_libraries() {
 
     # Install the latest PIP and setuptools.
-    # But first path it to get the exact version.
-    # get-pip will alwasy try to get the latest version, so we ask it to not
+    # But first patch it to get the exact version.
+    # get-pip will always try to get the latest version, so we ask it to not
     # install things and then we manually pass what we want to install.
     execute patch -p0 < python-modules/get-pip-pin.patch
     execute $PYTHON_BIN python-modules/get-pip.py $PIP_ARGS \
@@ -709,6 +710,7 @@ command_test_compat() {
     # For now it does nothing.
     # Here since the buildmaster was updated.
     # Will be overwritten in #4020.
+    echo "Skipping compat tests"
 }
 
 

--- a/chevah_build
+++ b/chevah_build
@@ -21,6 +21,8 @@ SQLITE_VERSION="3.17.0"
 PYSQLITE_VERSION="2.6.3"
 # These are used by the patched get-pip.py.
 # PIP_VERSION is already used by get-pip for something else.
+# For now, we can't use version 8 of pip as our PyPi server does not support
+# simplified names.
 export CHEVAH_PIP_VERSION="7.1.2"
 SETUPTOOLS_VERSION="20.3.1"
 

--- a/chevah_build
+++ b/chevah_build
@@ -545,8 +545,11 @@ command_build_python_extra_libraries() {
 
     # Install the latest PIP and setuptools.
     # But first path it to get the exact version.
+    # get-pip will alwasy try to get the latest version, so we ask it to not
+    # install things and then we manually pass what we want to install.
     execute patch -p0 < python-modules/get-pip-pin.patch
-    execute $PYTHON_BIN python-modules/get-pip.py $PIP_ARGS
+    execute $PYTHON_BIN python-modules/get-pip.py $PIP_ARGS \
+        --no-setuptools setuptools==$SETUPTOOLS_VERSION
 
     # pycparser is installed first as setup_requires is ugly.
     # https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires

--- a/python-modules/get-pip-pin.patch
+++ b/python-modules/get-pip-pin.patch
@@ -11,14 +11,3 @@ diff -ur python-modules/get-pip.py python-modules/get-pip.py
  
      # Check if the user has requested us not to install setuptools
      if "--no-setuptools" in sys.argv or os.environ.get("PIP_NO_SETUPTOOLS"):
-@@ -110,7 +111,9 @@
-         try:
-             import setuptools  # noqa
-         except ImportError:
--            packages += ["setuptools"]
-+            setuptools_version = os.environ.get(
-+                'SETUPTOOLS_VERSION', 'not-defined')
-+            packages += ["setuptools==" + setuptools_version]
- 
-     # Check if the user has requested us not to install wheel
-     if "--no-wheel" in args or os.environ.get("PIP_NO_WHEEL"):

--- a/python-modules/get-pip-pin.patch
+++ b/python-modules/get-pip-pin.patch
@@ -1,0 +1,24 @@
+diff -ur python-modules/get-pip.py python-modules/get-pip.py
+--- python-modules/get-pip.py
++++ python-modules/get-pip.py
+@@ -97,7 +97,8 @@
+     pip.commands_dict["install"] = CertInstallCommand
+ 
+     # We always want to install pip
+-    packages = ["pip"]
++    pip_version = os.environ.get('CHEVAH_PIP_VERSION', 'not-defined')
++    packages = ["pip==" + pip_version]
+ 
+     # Check if the user has requested us not to install setuptools
+     if "--no-setuptools" in sys.argv or os.environ.get("PIP_NO_SETUPTOOLS"):
+@@ -110,7 +111,9 @@
+         try:
+             import setuptools  # noqa
+         except ImportError:
+-            packages += ["setuptools"]
++            setuptools_version = os.environ.get(
++                'SETUPTOOLS_VERSION', 'not-defined')
++            packages += ["setuptools==" + setuptools_version]
+ 
+     # Check if the user has requested us not to install wheel
+     if "--no-wheel" in args or os.environ.get("PIP_NO_WHEEL"):


### PR DESCRIPTION
Scope
=====

This updates the build script for python to use a pinned version for pip and setuptools.

In previous code the latest version was used so if the pypi server was update, we would end up with different python distribution, for the same commit

Changes
=======

There is no way for get-pip.py to install a specific pip. it will always install the latest...so I had to patch it.

for setuptools there was a workarround 


How to try and test the changes
===============================

reviewers: @dumol 

check that changes make sense

we have newer setuptools in our pypi,chevah.com mirror.

you can try updating the chevah_build with an even older pip version and check that the requiest version is used

