### PR TITLE
[#4043] NetBSD support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -685,7 +685,7 @@ command_test() {
             execute $LOCAL_PYTHON_BINARY \
                 ../python-modules/python-scandir-1.5/test/run_tests.py
             ;;
-        aix*|solaris10*|hpux*|linux*|openbsd*)
+        aix*|solaris10*|hpux*|linux*|openbsd*|netbsd*)
             # In OpenBSD there are even more issues actually.
             # Details at https://github.com/benhoyt/scandir/issues/79.
             (>&2 echo -e "\tSkipping because of upstream issues.")

--- a/paver.sh
+++ b/paver.sh
@@ -539,6 +539,15 @@ detect_os() {
         check_os_version "OpenBSD" 5.9 "$os_version_raw" os_version_chevah
         OS="openbsd${os_version_chevah}"
 
+    elif [ "${OS}" = "netbsd" ]; then
+        ARCH=$(uname -m)
+
+        os_version_raw=$(uname -r | cut -d'.' -f1)
+        check_os_version "NetBSD" 7 "$os_version_raw" os_version_chevah
+
+        # For now, no matter the actual NetBSD version returned, we use '7'.
+        OS="netbsd7"
+
     else
         echo 'Unsupported operating system:' $OS
         exit 14

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -241,6 +241,23 @@ def get_allowed_deps():
             '/usr/lib/libz.so',
             '/usr/libexec/ld.so',
             ]
+    elif platform_system == 'netbsd':
+        # This is the list of specific deps for NetBSD 7.x, with paths.
+        allowed_deps = [
+            '/lib/libcrypt.so.1',
+            '/usr/lib/libc.so.12',
+            '/usr/lib/libcrypt.so.1',
+            '/usr/lib/libcrypto.so.8',
+            '/usr/lib/libcurses.so.7',
+            '/usr/lib/libgcc_s.so.1',
+            '/usr/lib/libintl.so.1',
+            '/usr/lib/libm.so.0',
+            '/usr/lib/libpthread.so.1',
+            '/usr/lib/libssl.so.10',
+            '/usr/lib/libterminfo.so.1',
+            '/usr/lib/libutil.so.7',
+            '/usr/lib/libz.so.1',
+            ]
     return allowed_deps
 
 
@@ -264,7 +281,7 @@ def get_actual_deps(script_helper):
                 # the current hierarchy of directories.
                 # In HP-UX, ldd also outputs an empty first line.
                 continue
-            if platform_system in [ 'sunos', 'hp-ux', 'freebsd' ]:
+            if platform_system in [ 'sunos', 'hp-ux', 'freebsd', 'netbsd' ]:
                 # When ignoring lines from the above conditions, ldd's output
                 # lists the libs with full path in the 3th colon on these OS'es.
                 dep = line.split()[2]


### PR DESCRIPTION
Scope
=====
I've been giving NetBSD 7.1 a try for some weeks, so why not add support for this OS while at it? :-]

Changes
=======

Added support for NetBSD 7.x in `paver.sh`.
Updated tests for NetBSD 7 amd64.
Built a package on my notebook and uploaded it, so that I have a working `paver.sh` locally.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/49