### PR TITLE
[#4132] Ubuntu 16.04 ARM64 support.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -76,6 +76,10 @@ def get_allowed_deps():
             allowed_deps.extend([
                 'libtinfo.so.5',
                 ])
+            if 'arm64' in chevah_arch:
+                allowed_deps.extend([
+                    'libgcc_s.so.1',
+                    ])
         elif ('raspbian' in chevah_os):
             allowed_deps.extend([
                 'libcofi_rpi.so',


### PR DESCRIPTION
Scope
=====

`python-package` builds fine on the new Pine64 board, but there's one additional dep on Ubuntu 16.04 compared to the arm64 build on Ubuntu 14.04. (Or perhaps last arm64 build was affected by the bug fixed in #66.)

Changes
=======

Simply added the missing dep for ARM64 builds on Ubuntu 16.04.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please check the change.
Run the automated tests, eg. https://chevah.com/buildbot/builders/python-package-ubuntu-1604-arm64/builds/3.