### PR TITLE
[#4128] Raspbian 8 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -700,7 +700,7 @@ command_test() {
             execute $LOCAL_PYTHON_BINARY \
                 ../python-modules/python-scandir-1.5/test/run_tests.py
             ;;
-        aix*|solaris10*|hpux*|linux*|openbsd*|netbsd*)
+        aix*|solaris10*|hpux*|linux*|raspbian*|openbsd*|netbsd*)
             # In OpenBSD there are even more issues actually.
             # Details at https://github.com/benhoyt/scandir/issues/79.
             (>&2 echo -e "\tSkipping because of upstream issues.")

--- a/paver.sh
+++ b/paver.sh
@@ -563,9 +563,7 @@ detect_os() {
                     grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
                 check_os_version "Raspbian GNU/Linux" 7 \
                     "$os_version_raw" os_version_chevah
-                # For now, we only generate a Raspbian version 7.x package,
-                # and we should use that in newer Raspbian versions too.
-                OS="raspbian7"
+                OS="raspbian${os_version_chevah}"
             fi
         elif [ $(command -v lsb_release) ]; then
             lsb_release_id=$(lsb_release -is)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -83,14 +83,17 @@ def get_allowed_deps():
         elif ('raspbian' in chevah_os):
             raspbian_version = int(chevah_os[8:])
             allowed_deps.extend([
-                'libcofi_rpi.so',
                 'libgcc_s.so.1',
                 'libncurses.so.5',
                 'libtinfo.so.5',
                 ])
-            if raspbian_version >= 8:
+            if raspbian_version == 7:
                 allowed_deps.extend([
-                    'libarmmem.so',
+                    '/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so',
+                    ])
+            elif raspbian_version >= 8:
+                allowed_deps.extend([
+                    '/usr/lib/arm-linux-gnueabihf/libarmmem.so',
                     ])
         else:
             # Debian 7 x64 (aka linux-x64) needs this for cffi.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -81,12 +81,17 @@ def get_allowed_deps():
                     'libgcc_s.so.1',
                     ])
         elif ('raspbian' in chevah_os):
+            raspbian_version = int(chevah_os[8:])
             allowed_deps.extend([
                 'libcofi_rpi.so',
                 'libgcc_s.so.1',
                 'libncurses.so.5',
                 'libtinfo.so.5',
                 ])
+            if raspbian_version >= 8:
+                allowed_deps.extend([
+                    'libarmmem.so',
+                    ])
         else:
             # Debian 7 x64 (aka linux-x64) needs this for cffi.
             allowed_deps.extend([


### PR DESCRIPTION
Scope
=====

On the new RPi 3 host we have Raspbian 8.
Although the `raspbian7` package actually works in Raspbian 8, we need to support this with native packages.

Changes
=======

Added missing dep.
No more hard-coding for version 7 in Raspbian.
No more `scandir` tests in Raspbian as they fail in version 8, even with UTF-8 locale present and set.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests, eg.
https://chevah.com/buildbot/builders/python-package-raspbian-7/builds/139
https://chevah.com/buildbot/builders/python-package-raspbian-8/builds/6