### PR TITLE
[#4154] OpenBSD 6.1 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -463,6 +463,7 @@ command_build() {
     # as copying the includes (HP-UX's linker fails with -I when not using GCC).
     mkdir -p $INSTALL_FOLDER/{include,lib}
     export LDFLAGS="-L${INSTALL_FOLDER}/lib/ ${LDFLAGS}"
+    export PKG_CONFIG_PATH="${INSTALL_FOLDER}/lib/pkgconfig/:${PKG_CONFIG_PATH}"
 
     if [ "$BUILD_LIBFFI" = "yes" ]; then
         build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}

--- a/chevah_build
+++ b/chevah_build
@@ -55,7 +55,7 @@ EXTRA_LIBRARIES_NO_CFFI="\
 PIP_LIBRARIES="\
     setproctitle==1.1.10 \
     cryptography==1.9 \
-    pyOpenSSL==16.0.0 \
+    pyOpenSSL==17.0.0 \
     scandir==1.5 \
     "
 # Pre-combiled libraries distributed as wheels for Windows.

--- a/chevah_build
+++ b/chevah_build
@@ -54,7 +54,7 @@ EXTRA_LIBRARIES_NO_CFFI="\
 # List of python modules installed using pip
 PIP_LIBRARIES="\
     setproctitle==1.1.10 \
-    cryptography==1.3.1 \
+    cryptography==1.9 \
     pyOpenSSL==16.0.0 \
     scandir==1.5 \
     "
@@ -254,11 +254,6 @@ case $OS in
         export CC="clang"
         export CXX="clang++"
         export BUILD_LIBEDIT="no"
-        ;;
-    openbsd*)
-        # cryptography fails to build with LibreSSL, use the packaged OpenSSL.
-        export LDFLAGS="-L/usr/local/eopenssl/lib $LDFLAGS"
-        export CPPFLAGS="$CPPFLAGS -I/usr/local/include/eopenssl"
         ;;
     archlinux)
         export BUILD_LIBEDIT="no"

--- a/chevah_build
+++ b/chevah_build
@@ -751,9 +751,8 @@ command_test_compat() {
     # download it.
     execute mkdir cache
     execute cp -r ../$LOCAL_PYTHON_BINARY_DIST cache/
-    # For now, this test is just informative, so even if we fail, we are OK.
     # Some tests might fail due to causes which are not related to python.
-    ./paver.sh test_ci
+    execute ./paver.sh test_ci
     execute popd
 
     execute popd

--- a/chevah_build
+++ b/chevah_build
@@ -255,6 +255,11 @@ case $OS in
         export CXX="clang++"
         export BUILD_LIBEDIT="no"
         ;;
+    openbsd*)
+        # cryptography fails to build with LibreSSL, use the packaged OpenSSL.
+        export LDFLAGS="-L/usr/local/eopenssl/lib $LDFLAGS"
+        export CPPFLAGS="$CPPFLAGS -I/usr/local/include/eopenssl"
+        ;;
     archlinux)
         export BUILD_LIBEDIT="no"
         ;;

--- a/chevah_build
+++ b/chevah_build
@@ -94,8 +94,7 @@ RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
 SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
 if [ $OS = 'sles10' ]; then
     SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
-fi
-if [ $OS = 'rhel5' ]; then
+elif [ $OS = 'rhel5' ]; then
     RHEL_PACKAGES="$RHEL_PACKAGES automake15"
 fi
 
@@ -264,7 +263,8 @@ case $OS in
         # and the result is not portable.
         export BUILD_LIBEDIT="no"
         ;;
-    sles10)
+    sles10|sles11|rhel5)
+        # Up-to-date cryptography not working on these...
         export BUILD_CFFI="no"
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI

--- a/chevah_build
+++ b/chevah_build
@@ -263,8 +263,16 @@ case $OS in
         # and the result is not portable.
         export BUILD_LIBEDIT="no"
         ;;
-    sles10|sles11|rhel5)
+    rhel5|sles11)
         # Up-to-date cryptography not working on these...
+        PIP_LIBRARIES="\
+            setproctitle==1.1.10 \
+            cryptography==1.3.1 \
+            pyOpenSSL==16.0.0 \
+            scandir==1.5 \
+            "
+        ;;
+    sles10)
         export BUILD_CFFI="no"
         PIP_LIBRARIES=""
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI

--- a/functions.sh
+++ b/functions.sh
@@ -243,6 +243,9 @@ wipe_manifest() {
 
 get_number_of_cpus() {
     case "$OS" in
+        windows*)
+            CPUS="$NUMBER_OF_PROCESSORS"
+            ;;
         aix*)
             # This works in an AIX 5.3 vWPAR too.
             CPUS=$(lparstat -i | grep ^"Maximum Physical CPUs" | cut -d\: -f2)
@@ -260,7 +263,7 @@ get_number_of_cpus() {
             ;;
         *)
             # Only Linux distros should be left.
-            # Don't use lscpu/nproc, as they are not present on older distros.
+            # Don't use lscpu/nproc or other stuff not present on older distros.
             CPUS=$(getconf _NPROCESSORS_ONLN)
             ;;
     esac

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -421,7 +421,7 @@ def main():
 
             if chevah_os == 'windows':
                 # Check OpenSSL version on windows.
-                expecting = u'OpenSSL 1.0.2g  1 Mar 2016'
+                expecting = u'OpenSSL 1.1.0f  25 May 2017'
                 if openssl_version != expecting:
                     sys.stderr.write('Expecting %s got %s.\n' % (
                         expecting, openssl_version))

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -118,6 +118,8 @@ chevahbs_configure() {
             CONFIG_ARGS="${CONFIG_ARGS} --without-gcc"
             ;;
         openbsd*)
+            # In OpenBSD 6.1 and newer we need to mark the Python binary as
+            # "wxneeded" because it breaks the mandatory W^X protection.
             LDFLAGS="$LDFLAGS -Wl,-z,wxneeded"
             ;;
     esac

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -117,6 +117,9 @@ chevahbs_configure() {
         osx*|macos*)
             CONFIG_ARGS="${CONFIG_ARGS} --without-gcc"
             ;;
+        openbsd*)
+            LDFLAGS="$LDFLAGS -Wl,-z,wxneeded"
+            ;;
     esac
 
     # This requires the v4 patch from https://bugs.python.org/issue13501.


### PR DESCRIPTION
Scope
=====

OpenBSD 6.1 is the latest stable version.
Current code doesn't build on OpenBSD 6.1.

Changes
=======

Use `wxneeded` flag when linking the Python binary in OpenBSD. In 6.1 it's not enough to mark the current filesystem as `wxallowed` for binaries to be exempted from the W^X policy.

Updated `cryptography` to latest version.
This also required newer `cffi` and `asn1crypto`.
For some OS'es, latest `pyOpenSSL` was needed.
Still, some older OS'es didn't build `cryptography`, so the following actions were taken:
  * for OS X 10.8, the upstream wheel was uploaded (this is used in MacOS 10.12 too)
  * for RHEL 5 and SLES 11 we make an exception and still use the old set of PIP_LIBRARIES.

**Drive-by fix**:
  * get the number of processors in Windows too to silence a warning during the test phase.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the automated tests, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/0