### PR TITLE
[#4198] Support for SLES 11 with Security Module.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -92,10 +92,12 @@ COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
 DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
 RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
 SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
-if [ $OS = 'sles10' ]; then
-    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
-elif [ $OS = 'rhel5' ]; then
+if [ $OS = 'rhel5' ]; then
     RHEL_PACKAGES="$RHEL_PACKAGES automake15"
+elif [ $OS = 'sles10' ]; then
+    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
+elif [ $OS = 'sles11sm' ]; then
+    SLES_PACKAGES="$COMMON_PACKAGES libopenssl1-devel zlib-devel ncurses-devel"
 fi
 
 # List of OS packages requested to be installed by this script.

--- a/chevah_build
+++ b/chevah_build
@@ -97,6 +97,7 @@ if [ $OS = 'rhel5' ]; then
 elif [ $OS = 'sles10' ]; then
     SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
 elif [ $OS = 'sles11sm' ]; then
+    # SLES 11 with Security Module detected, we need the OpenSSL 1.0.x headers.
     SLES_PACKAGES="$COMMON_PACKAGES libopenssl1-devel zlib-devel ncurses-devel"
 fi
 

--- a/chevah_build
+++ b/chevah_build
@@ -241,6 +241,13 @@ case $OS in
         export CXX="clang++"
         export CFLAGS="$CFLAGS -mmacosx-version-min=10.8"
         export MACOSX_DEPLOYMENT_TARGET=10.8
+        # OS X 10.8 not supported by cryptography 1.9, so we use 1.8.2.
+        PIP_LIBRARIES="\
+            setproctitle==1.1.10 \
+            cryptography==1.8.2 \
+            pyOpenSSL==17.0.0 \
+            scandir==1.5 \
+            "
         ;;
     macos*)
         # On macOS 10.12 or newer we need the Homebrew version of OpenSSL,

--- a/paver.conf
+++ b/paver.conf
@@ -1,7 +1,4 @@
-BRINK_VERSION='0.61.2'
+BASE_REQUIREMENTS='brink==0.63.3 paver==1.2.4'
 PYTHON_CONFIGURATION='default@2.7.13.4f815b5:solaris10@2.7.8.4f815b5'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'
-PAVER_VERSION='1.2.4'
-PIP_VERSION="1.4.1.c4"
-SETUPTOOLS_VERSION="1.4.1"

--- a/paver.sh
+++ b/paver.sh
@@ -544,8 +544,8 @@ detect_os() {
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
                 if [ ${os_version_chevah} -eq 11 ]; then
-                    # Check for SLES 11 with OpenSSL 1.0 (aka Security Module).
-                    if [ -n $(rpm -q openssl1) ]; then
+                    # In 11.x check for OpenSSL 1.0.x (aka Security Module).
+                    if [ -x /usr/bin/openssl1 ]; then
                         OS="sles11sm"
                     fi
                 fi

--- a/paver.sh
+++ b/paver.sh
@@ -67,7 +67,7 @@ PYTHON_PLATFORM='unknown-os-and-arch'
 PYTHON_NAME='python2.7'
 BINARY_DIST_URI='https://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'
-PAVER_VERSION='1.2.1'
+BASE_REQUIREMENTS=''
 
 # Load repo specific configuration.
 source paver.conf
@@ -218,17 +218,8 @@ write_default_values() {
 # Install base package.
 #
 install_base_deps() {
-    local base_packages
-    base_packages="paver==$PAVER_VERSION"
-    if [ "$BRINK_VERSION" = "skip" ]; then
-        echo "Skipping brink installation."
-    else
-        base_packages="$base_packages chevah-brink==$BRINK_VERSION"
-    fi
-
-    echo "Installing $base_packages."
-
-    pip_install "$base_packages"
+    echo "Installing base requirements: $BASE_REQUIREMENTS."
+    pip_install "$BASE_REQUIREMENTS"
 }
 
 

--- a/paver.sh
+++ b/paver.sh
@@ -543,11 +543,9 @@ detect_os() {
                 check_os_version "SUSE Linux Enterprise Server" 10 \
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
-                if [ ${os_version_chevah} -eq 11 ]; then
-                    # In 11.x check for OpenSSL 1.0.x (aka Security Module).
-                    if [ -x /usr/bin/openssl1 ]; then
-                        OS="sles11sm"
-                    fi
+                # On 11.x, check for OpenSSL 1.0.x (a.k.a. Security Module).
+                if [ ${os_version_chevah} -eq 11 -a -x /usr/bin/openssl1 ]; then
+                    OS="sles11sm"
                 fi
             fi
         elif [ -f /etc/arch-release ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -552,6 +552,12 @@ detect_os() {
                 check_os_version "SUSE Linux Enterprise Server" 10 \
                     "$os_version_raw" os_version_chevah
                 OS="sles${os_version_chevah}"
+                if [ ${os_version_chevah} -eq 11 ]; then
+                    # Check for SLES 11 with OpenSSL 1.0 (aka Security Module).
+                    if [ -n $(rpm -q openssl1) ]; then
+                        OS="sles11sm"
+                    fi
+                fi
             fi
         elif [ -f /etc/arch-release ]; then
             # ArchLinux is a rolling distro, no version info available.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -64,7 +64,7 @@ def get_allowed_deps():
                     'libpcre.so.1',
                     ])
         elif ('sles' in chevah_os):
-            sles_version = int(chevah_os[4:])
+            sles_version = int(chevah_os[4:6])
             allowed_deps.extend([
                 'libncursesw.so.5',
                 ])


### PR DESCRIPTION
Scope
=====

Build with the OpenSSL 1.0.x from the Security Module repo on SLES 11. Therefore, use updated cryptography.

Changes
=======

Patched `paver.sh` to check for `libopenssl1` RPM in SUSE 11.
Defined new `chevah_os` for this SLES11/OpenSSL 1.0.x combo as `sles11sm`.
Patched `chevah_build` to install `libopenssl1-dev` if needed in SLES 11 with SM.
Patched `test_python_binary_dist.py` to account for the `sles11sm` moniker.

**Drive-by fix:**
  * use `cryptography` 1.8.3 on OS X, as our 10.8 is not supported in 1.9.0.

How to try and test the changes
===============================

reviewers: @adiroiban 

Build the package in SLES 11 SM and checked for updated cryptography linked to the OpenSSL 1.0.x lib from the Security Module.
Build the package in SLES 11 without SM to check for possible breakage.
Run the automated test suite.