### PR TITLE
[#4244] Build only 32bit binaries on Solaris.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -180,8 +180,6 @@ case $OS in
         if [ "$OS" = "solaris10u3" ]; then
             # pip doesn't like the included zlib from this old Solaris release.
             export BUILD_ZLIB="yes"
-            # GMP needs to be told that we aim for a 32bit build.
-            export ABI="32"
         fi
         # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then
@@ -190,6 +188,8 @@ case $OS in
         # The location for GNU libs in Solaris, including OpenSSL in Solaris 10.
         if [ "${ARCH%64}" = "$ARCH" ]; then
             export LDFLAGS="$LDFLAGS -L/usr/sfw/lib -R/usr/sfw/lib"
+            # GMP needs to be told that we aim for a 32bit build.
+            export ABI="32"
         else
             export LDFLAGS="$LDFLAGS -m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="$CFLAGS -m64"

--- a/chevah_build
+++ b/chevah_build
@@ -760,6 +760,8 @@ command_test_compat() {
     # PYTHON_CONFIGURATION with only one option breaks paver.sh.
     # For now, have added an extra ':' at the end to make things work.
     execute echo -e "\nPYTHON_CONFIGURATION=default@${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}:" >> paver.conf
+    # Also copy latest paver.sh, as some changes might require it.
+    execute cp ../../paver.sh ./
     # Populate the cache with the latest version so that we don't have to
     # download it.
     execute mkdir cache

--- a/chevah_build
+++ b/chevah_build
@@ -756,7 +756,10 @@ command_test_compat() {
     execute pushd compat
     # We patch the Python version to match the one that we have just built
     # and copy it in cache so that it will be picked up by the new build.
-    execute echo -e "\nPYTHON_CONFIGURATION=${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}" >> paver.conf
+    # FIXME:4247:
+    # PYTHON_CONFIGURATION with only one option breaks paver.sh.
+    # For now, have added an extra ':' at the end to make things work.
+    execute echo -e "\nPYTHON_CONFIGURATION=default@${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}:" >> paver.conf
     # Populate the cache with the latest version so that we don't have to
     # download it.
     execute mkdir cache

--- a/paver.sh
+++ b/paver.sh
@@ -621,13 +621,17 @@ detect_os() {
         exit 14
     fi
 
-    # Fix arch names.
+    # Fix arch names. Force 32bit builds on problematic OS'es.
     if [ "$ARCH" = "i686" -o "$ARCH" = "i386" ]; then
         ARCH='x86'
-    elif [ "$ARCH" = "x86_64" -o "$ARCH" = "amd64" ]; then
+    elif [ "$ARCH" = "amd64" -a "${OS%solaris*}" = "" ]; then
+        # Huge RAM usage on Solaris, so we build 32bit binaries.
+        ARCH='x86'
+    elif [ "$ARCH" = "amd64" -o "$ARCH" = "x86_64" ]; then
         ARCH='x64'
     elif [ "$ARCH" = "sparcv9" ]; then
-        ARCH='sparc64'
+        # Huge RAM usage on Solaris, so we build 32bit binaries.
+        ARCH='sparc'
     elif [ "$ARCH" = "ppc64" ]; then
         # Python has not been fully tested on AIX when compiled as a 64 bit
         # binary, and has math rounding error problems (at least with XL C).

--- a/paver.sh
+++ b/paver.sh
@@ -621,20 +621,16 @@ detect_os() {
         exit 14
     fi
 
-    # Normalize arch names. Force 32bit builds on problematic OS'es.
+    # Normalize arch names. Force 32bit builds on some OS'es.
     case "$ARCH" in
         "i386"|"i686")
             ARCH="x86"
             ;;
         "amd64"|"x86_64")
             ARCH="x64"
-            if [ "${OS%solaris*}" = "" ]; then
-            # We build 32bit binaries on Solaris, to err on the safe side.
-                ARCH="x86"
-            fi
             ;;
         "sparcv9")
-            # The other choice would be "sparc64", but we err on the safe side.
+            # We build 32bit binaries on SPARC. Use "sparc64" for 64bit builds.
             ARCH="sparc"
             ;;
         "ppc64")

--- a/paver.sh
+++ b/paver.sh
@@ -621,24 +621,31 @@ detect_os() {
         exit 14
     fi
 
-    # Fix arch names. Force 32bit builds on problematic OS'es.
-    if [ "$ARCH" = "i686" -o "$ARCH" = "i386" ]; then
-        ARCH='x86'
-    elif [ "$ARCH" = "amd64" -a "${OS%solaris*}" = "" ]; then
-        # Huge RAM usage on Solaris, so we build 32bit binaries.
-        ARCH='x86'
-    elif [ "$ARCH" = "amd64" -o "$ARCH" = "x86_64" ]; then
-        ARCH='x64'
-    elif [ "$ARCH" = "sparcv9" ]; then
-        # Huge RAM usage on Solaris, so we build 32bit binaries.
-        ARCH='sparc'
-    elif [ "$ARCH" = "ppc64" ]; then
-        # Python has not been fully tested on AIX when compiled as a 64 bit
-        # binary, and has math rounding error problems (at least with XL C).
-        ARCH='ppc'
-    elif [ "$ARCH" = "aarch64" ]; then
-        ARCH='arm64'
-    fi
+    # Normalize arch names. Force 32bit builds on problematic OS'es.
+    case "$ARCH" in
+        "i386"|"i686")
+            ARCH="x86"
+            ;;
+        "amd64"|"x86_64")
+            ARCH="x64"
+            if [ "${OS%solaris*}" = "" ]; then
+            # We build 32bit binaries on Solaris, to err on the safe side.
+                ARCH="x86"
+            fi
+            ;;
+        "sparcv9")
+            # The other choice would be "sparc64", but we err on the safe side.
+            ARCH="sparc"
+            ;;
+        "ppc64")
+            # Python has not been fully tested on AIX when compiled as a 64 bit
+            # binary, and has math rounding error problems (at least with XL C).
+            ARCH="ppc"
+            ;;
+        "aarch64")
+            ARCH="arm64"
+            ;;
+    esac
 }
 
 detect_os

--- a/paver.sh
+++ b/paver.sh
@@ -629,17 +629,17 @@ detect_os() {
         "amd64"|"x86_64")
             ARCH="x64"
             ;;
-        "sparcv9")
-            # We build 32bit binaries on SPARC. Use "sparc64" for 64bit builds.
-            ARCH="sparc"
+        "aarch64")
+            ARCH="arm64"
             ;;
         "ppc64")
-            # Python has not been fully tested on AIX when compiled as a 64 bit
+            # Python has not been fully tested on AIX when compiled as a 64bit
             # binary, and has math rounding error problems (at least with XL C).
             ARCH="ppc"
             ;;
-        "aarch64")
-            ARCH="arm64"
+        "sparcv9")
+            # We build 32bit binaries on SPARC too. Use "sparc64" for 64bit.
+            ARCH="sparc"
             ;;
     esac
 }

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -124,6 +124,8 @@ def get_allowed_deps():
                 'libthread.a',
                 ])
     elif platform_system == 'sunos':
+        # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
+        solaris_version = platform.release().split('.')[1]
         if '64' in chevah_arch:
             # This is the common list of deps for Solaris 10 & 11 64bit builds.
             allowed_deps = [
@@ -134,8 +136,6 @@ def get_allowed_deps():
                 '/lib/64/libnsl.so.1',
                 '/lib/64/libsocket.so.1',
                 ]
-            # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
-            solaris_version = platform.release().split('.')[1]
             if solaris_version == '10':
                 # Specific deps to add for Solaris 10.
                 allowed_deps.extend([
@@ -169,25 +169,50 @@ def get_allowed_deps():
                         '/usr/lib/amd64/libc.so.1',
                         ])
         else:
-            # Full deps for Solaris 10u3 x86 (and possibly other 32bit builds).
+            # This is the common list of deps for Solaris 10 & 11 32bit builds.
             allowed_deps = [
-                '/lib/libaio.so.1',
                 '/lib/libc.so.1',
                 '/lib/libdl.so.1',
-                '/lib/libgen.so.1',
                 '/lib/libintl.so.1',
                 '/lib/libm.so.2',
-                '/lib/libmd5.so.1',
                 '/lib/libnsl.so.1',
                 '/lib/libsocket.so.1',
-                '/lib/libresolv.so.2',
-                '/lib/librt.so.1',
-                '/usr/lib/libcrypt_i.so.1',
-                '/usr/lib/mps/libsqlite3.so.0',
-                '/usr/sfw/lib//libgcc_s.so.1',
-                '/usr/sfw/lib//libcrypto.so.0.9.7',
-                '/usr/sfw/lib//libssl.so.0.9.7',
                 ]
+            if solaris_version == '10':
+                # Specific deps to add for all Solaris 10 versions.
+                allowed_deps.extend([
+                    '/lib/libaio.so.1',
+                    '/lib/libgen.so.1',
+                    '/lib/librt.so.1',
+                    '/usr/lib/libcrypt_i.so.1',
+                    '/usr/sfw/lib//libcrypto.so.0.9.7',
+                    '/usr/sfw/lib//libssl.so.0.9.7',
+                    ])
+                if 'solaris10u3' in chevah_os:
+                    # Specific deps for Solaris 10u3 up to 10u7.
+                    allowed_deps.extend([
+                        '/lib/libmd5.so.1',
+                        '/lib/libresolv.so.2',
+                        '/usr/lib/mps/libsqlite3.so.0',
+                        '/usr/sfw/lib//libgcc_s.so.1',
+                        ])
+                else:
+                    # Specific deps for Solaris 10u8 and newer.
+                    allowed_deps.extend([
+                        '/lib/libmd.so.1',
+                        '/usr/lib/libz.so.1',
+                        '/usr/lib/mps/libsqlite3.so',
+                        '/lib/libthread.so.1',
+                        ])
+            elif solaris_version == '11':
+                # Specific deps to add for Solaris 11.
+                allowed_deps.extend([
+                    '/lib/libcrypto.so.1.0.0',
+                    '/lib/libssl.so.1.0.0',
+                    '/lib/libz.so.1',
+                    '/usr/lib/libcrypt.so.1',
+                    '/usr/lib/libsqlite3.so.0',
+                    ])
     elif platform_system == 'hp-ux':
         # Specific deps for HP-UX 11.31, with full path.
         allowed_deps = [


### PR DESCRIPTION
Scope
=====

RAM usage issues on Solaris 10 SPARC. Let's see if 32binaries on Solaris would alleviate this. On the other commercial UNIX'es (AIX and HP-UX) we only have 32bit binaries.

Changes
=======

Force 32bit builds on Solaris.
Replaced `if` with `case` for normalizing arch names in `paver.sh`.
Completed deps list for 32bit builds on Solaris.
Worked around an issue with forcing the new Python version for compat tests.
Also use current `paver.sh` to overwrite the one in `compat` (needed in this case because of the arch switch for Solaris).

**Things to discuss**:
  * should we force 32bit builds only for sparc (and not for amd64?)
  * should we fix `paver.sh` everywhere to accept single versions without a _default@_ prefix or should we mandate the prefix and a suffix of `:`?
 * is there any downside to overwriting `paver.sh` for the compat tests?

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests.
Check that 32bit binaries are built for all Solaris versions.