### PR TITLE
[#4070] FreeBSD 11 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -756,10 +756,7 @@ command_test_compat() {
     execute pushd compat
     # We patch the Python version to match the one that we have just built
     # and copy it in cache so that it will be picked up by the new build.
-    # FIXME:4247:
-    # PYTHON_CONFIGURATION with only one option breaks paver.sh.
-    # For now, have added an extra ':' at the end to make things work.
-    execute echo -e "\nPYTHON_CONFIGURATION=default@${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}:" >> paver.conf
+    execute echo -e "\nPYTHON_CONFIGURATION=default@${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}" >> paver.conf
     # Also copy latest paver.sh, as some changes might require it.
     execute cp ../../paver.sh ./
     # Populate the cache with the latest version so that we don't have to

--- a/chevah_build
+++ b/chevah_build
@@ -180,8 +180,6 @@ case $OS in
         if [ "$OS" = "solaris10u3" ]; then
             # pip doesn't like the included zlib from this old Solaris release.
             export BUILD_ZLIB="yes"
-            # GMP needs to be told that we aim for a 32bit build.
-            export ABI="32"
         fi
         # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then
@@ -190,6 +188,8 @@ case $OS in
         # The location for GNU libs in Solaris, including OpenSSL in Solaris 10.
         if [ "${ARCH%64}" = "$ARCH" ]; then
             export LDFLAGS="$LDFLAGS -L/usr/sfw/lib -R/usr/sfw/lib"
+            # GMP needs to be told that we aim for a 32bit build.
+            export ABI="32"
         else
             export LDFLAGS="$LDFLAGS -m64 -L/usr/sfw/lib/64 -R/usr/sfw/lib/64"
             export CFLAGS="$CFLAGS -m64"
@@ -756,7 +756,12 @@ command_test_compat() {
     execute pushd compat
     # We patch the Python version to match the one that we have just built
     # and copy it in cache so that it will be picked up by the new build.
-    execute echo -e "\nPYTHON_CONFIGURATION=${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}" >> paver.conf
+    # FIXME:4247:
+    # PYTHON_CONFIGURATION with only one option breaks paver.sh.
+    # For now, have added an extra ':' at the end to make things work.
+    execute echo -e "\nPYTHON_CONFIGURATION=default@${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}:" >> paver.conf
+    # Also copy latest paver.sh, as some changes might require it.
+    execute cp ../../paver.sh ./
     # Populate the cache with the latest version so that we don't have to
     # download it.
     execute mkdir cache

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d'
+PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca'
 BASE_REQUIREMENTS='chevah-brink==0.63.3 paver==1.2.4'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca'
-BASE_REQUIREMENTS='chevah-brink==0.63.3 paver==1.2.4'
+BASE_REQUIREMENTS='chevah-brink==0.63.4 paver==1.2.4'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='brink==0.63.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.13.4f815b5:solaris10@2.7.8.4f815b5'
+PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -621,20 +621,27 @@ detect_os() {
         exit 14
     fi
 
-    # Fix arch names.
-    if [ "$ARCH" = "i686" -o "$ARCH" = "i386" ]; then
-        ARCH='x86'
-    elif [ "$ARCH" = "x86_64" -o "$ARCH" = "amd64" ]; then
-        ARCH='x64'
-    elif [ "$ARCH" = "sparcv9" ]; then
-        ARCH='sparc64'
-    elif [ "$ARCH" = "ppc64" ]; then
-        # Python has not been fully tested on AIX when compiled as a 64 bit
-        # binary, and has math rounding error problems (at least with XL C).
-        ARCH='ppc'
-    elif [ "$ARCH" = "aarch64" ]; then
-        ARCH='arm64'
-    fi
+    # Normalize arch names. Force 32bit builds on some OS'es.
+    case "$ARCH" in
+        "i386"|"i686")
+            ARCH="x86"
+            ;;
+        "amd64"|"x86_64")
+            ARCH="x64"
+            ;;
+        "aarch64")
+            ARCH="arm64"
+            ;;
+        "ppc64")
+            # Python has not been fully tested on AIX when compiled as a 64bit
+            # binary, and has math rounding error problems (at least with XL C).
+            ARCH="ppc"
+            ;;
+        "sparcv9")
+            # We build 32bit binaries on SPARC too. Use "sparc64" for 64bit.
+            ARCH="sparc"
+            ;;
+    esac
 }
 
 detect_os

--- a/paver.sh
+++ b/paver.sh
@@ -185,18 +185,18 @@ update_path_variables() {
 #
 resolve_python_version() {
     local version_configuration=$PYTHON_CONFIGURATION
+    local version_configuration_array
     local candidate
     local candidate_platform
     local candidate_version
 
     PYTHON_PLATFORM="$OS-$ARCH"
 
-    versions=$(echo "$version_configuration" | grep -c ":")
-    counter=0
-    while [ $counter -le $versions ]; do
-        # Number of delimiters is one less than the number of versions.
-        let counter=counter+1
-        candidate=$(echo "$version_configuration" | cut -d ":" -f $counter)
+    # Using ':' as a delimiter, populate a dedicated array.
+    IFS=: read -a version_configuration_array <<< "$version_configuration"
+    # Iterate through all the elements of the array to find the best candidate.
+    for (( i=0 ; i < ${#version_configuration_array[@]}; i++ )); do
+        candidate="${version_configuration_array[$i]}"
         candidate_platform=$(echo "$candidate" | cut -d "@" -f 1)
         candidate_version=$(echo "$candidate" | cut -d "@" -f 2)
         if [ "$candidate_platform" = "default" ]; then
@@ -297,6 +297,7 @@ test_version_exists() {
 #
 get_python_dist() {
     local remote_base_url=$1
+    local download_mode=$2
     local python_distributable=python-${PYTHON_VERSION}-${OS}-${ARCH}
     local wget_test
 
@@ -309,6 +310,10 @@ get_python_dist() {
         # We have the requested python version.
         get_binary_dist $python_distributable $remote_base_url/${OS}/${ARCH}
     else
+        if [ $download_mode == "strict" ]; then
+            echo "The requested version was not found on the remote server."
+            exit 1
+        fi
         # Fall back to the non-versioned distribution.
         echo "!!!Getting FALLBACK version!!!"
         get_binary_dist $PYTHON_NAME-$OS-$ARCH $remote_base_url
@@ -336,18 +341,36 @@ copy_python() {
 
     # Check that python dist was installed
     if [ ! -s ${PYTHON_BIN} ]; then
-        # Install python-dist since everything else depends on it.
+        # We don't have a Python binary, so we install it since everything
+        # else depends on it.
         echo "Bootstrapping ${LOCAL_PYTHON_BINARY_DIST} environment" \
             "to ${BUILD_FOLDER}..."
         mkdir -p ${BUILD_FOLDER}
 
-        # If we don't have a cached python distributable,
-        # get one together with default build system.
+        if [ -d ${python_distributable} ]; then
+            # We have a cached distributable.
+            # Check if is at the right version.
+            local cache_ver_file
+            cache_ver_file=${python_distributable}/lib/PYTHON_PACKAGE_VERSION
+            cache_version='UNVERSIONED'
+            if [ -f cache_ver_file ]; then
+                cache_version=`cat $cache_ver_file`
+            fi
+            if [ "$PYTHON_VERSION" != "$cache_version" ]; then
+                # We have a different version in the cache.
+                # Just remove it and hope that the next step will download
+                # the right one.
+                rm -rf ${python_distributable}
+            fi
+        fi
+
         if [ ! -d ${python_distributable} ]; then
+            # We don't have a cached python distributable.
             echo "No ${LOCAL_PYTHON_BINARY_DIST} environment." \
                 "Start downloading it..."
-            get_python_dist "$BINARY_DIST_URI/python"
+            get_python_dist "$BINARY_DIST_URI/python" "strict"
         fi
+
         echo "Copying Python distribution files... "
         cp -R ${python_distributable}/* ${BUILD_FOLDER}
 
@@ -356,10 +379,26 @@ copy_python() {
     else
         # We have a Python, but we are not sure if is the right version.
         local version_file=${BUILD_FOLDER}/lib/PYTHON_PACKAGE_VERSION
+
         if [ -f $version_file ]; then
+            # We have a versioned distribution.
             python_installed_version=`cat $version_file`
             if [ "$PYTHON_VERSION" != "$python_installed_version" ]; then
                 # We have a different python installed.
+
+                # Check if we have the to-be-updated version and fail if
+                # it does not exists.
+                set +o errexit
+                test_version_exists "$BINARY_DIST_URI/python"
+                local test_version=$?
+                set -o errexit
+                if [ $test_version -ne 0 ]; then
+                    echo "The build is now at $python_installed_version"
+                    echo "Failed to find the required $PYTHON_VERSION"
+                    echo "Check your configuration or the remote server."
+                    exit 1
+                fi
+
                 # Remove it and try to install it again.
                 echo "Updating Python from" \
                     $python_installed_version to $PYTHON_VERSION
@@ -666,7 +705,7 @@ if [ "$COMMAND" = "get_python" ] ; then
     OS=$2
     ARCH=$3
     resolve_python_version
-    get_python_dist "$BINARY_DIST_URI/python"
+    get_python_dist "$BINARY_DIST_URI/python" "fallback"
     exit 0
 fi
 

--- a/paver.sh
+++ b/paver.sh
@@ -353,7 +353,7 @@ copy_python() {
             local cache_ver_file
             cache_ver_file=${python_distributable}/lib/PYTHON_PACKAGE_VERSION
             cache_version='UNVERSIONED'
-            if [ -f cache_ver_file ]; then
+            if [ -f $cache_ver_file ]; then
                 cache_version=`cat $cache_ver_file`
             fi
             if [ "$PYTHON_VERSION" != "$cache_version" ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -636,8 +636,7 @@ detect_os() {
         os_version_raw=$(uname -r | cut -d'.' -f1)
         check_os_version "FreeBSD" 10 "$os_version_raw" os_version_chevah
 
-        # For now, no matter the actual FreeBSD version returned, we use '10'.
-        OS="freebsd10"
+        OS="freebsd${os_version_chevah}"
 
     elif [ "${OS}" = "openbsd" ]; then
         ARCH=$(uname -m)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -265,18 +265,18 @@ def get_allowed_deps():
             ]
         # On FreeBSD this can be: '10.3-RELEASE-p20', '11.0-RELEASE', etc.
         freebsd_version = platform.release().split('.')[0]
-	if freebsd_version == '10':
-	    # Additional deps, specific for FreeBSD 10.
-	    allowed_deps.extend([
-		'/lib/libcrypto.so.7',
-		'/usr/lib/libssl.so.7',
-	    ])
-	else:
-	    # Additional deps, specific for FreeBSD 11 and maybe newer.
-	    allowed_deps.extend([
-		'/lib/libcrypto.so.8',
-		'/usr/lib/libssl.so.8',
-	    ])
+        if freebsd_version == '10':
+            # Additional deps, specific for FreeBSD 10.
+            allowed_deps.extend([
+                '/lib/libcrypto.so.7',
+                '/usr/lib/libssl.so.7',
+            ])
+        else:
+            # Additional deps, specific for FreeBSD 11 and maybe newer.
+            allowed_deps.extend([
+                '/lib/libcrypto.so.8',
+                '/usr/lib/libssl.so.8',
+            ])
     elif platform_system == 'openbsd':
         # This is the list of deps for OpenBSD 5.8 or newer, sans versions.
         allowed_deps = [

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -124,6 +124,8 @@ def get_allowed_deps():
                 'libthread.a',
                 ])
     elif platform_system == 'sunos':
+        # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
+        solaris_version = platform.release().split('.')[1]
         if '64' in chevah_arch:
             # This is the common list of deps for Solaris 10 & 11 64bit builds.
             allowed_deps = [
@@ -134,8 +136,6 @@ def get_allowed_deps():
                 '/lib/64/libnsl.so.1',
                 '/lib/64/libsocket.so.1',
                 ]
-            # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
-            solaris_version = platform.release().split('.')[1]
             if solaris_version == '10':
                 # Specific deps to add for Solaris 10.
                 allowed_deps.extend([
@@ -169,25 +169,50 @@ def get_allowed_deps():
                         '/usr/lib/amd64/libc.so.1',
                         ])
         else:
-            # Full deps for Solaris 10u3 x86 (and possibly other 32bit builds).
+            # This is the common list of deps for Solaris 10 & 11 32bit builds.
             allowed_deps = [
-                '/lib/libaio.so.1',
                 '/lib/libc.so.1',
                 '/lib/libdl.so.1',
-                '/lib/libgen.so.1',
                 '/lib/libintl.so.1',
                 '/lib/libm.so.2',
-                '/lib/libmd5.so.1',
                 '/lib/libnsl.so.1',
                 '/lib/libsocket.so.1',
-                '/lib/libresolv.so.2',
-                '/lib/librt.so.1',
-                '/usr/lib/libcrypt_i.so.1',
-                '/usr/lib/mps/libsqlite3.so.0',
-                '/usr/sfw/lib//libgcc_s.so.1',
-                '/usr/sfw/lib//libcrypto.so.0.9.7',
-                '/usr/sfw/lib//libssl.so.0.9.7',
                 ]
+            if solaris_version == '10':
+                # Specific deps to add for all Solaris 10 versions.
+                allowed_deps.extend([
+                    '/lib/libaio.so.1',
+                    '/lib/libgen.so.1',
+                    '/lib/librt.so.1',
+                    '/usr/lib/libcrypt_i.so.1',
+                    '/usr/sfw/lib//libcrypto.so.0.9.7',
+                    '/usr/sfw/lib//libssl.so.0.9.7',
+                    ])
+                if 'solaris10u3' in chevah_os:
+                    # Specific deps for Solaris 10u3 up to 10u7.
+                    allowed_deps.extend([
+                        '/lib/libmd5.so.1',
+                        '/lib/libresolv.so.2',
+                        '/usr/lib/mps/libsqlite3.so.0',
+                        '/usr/sfw/lib//libgcc_s.so.1',
+                        ])
+                else:
+                    # Specific deps for Solaris 10u8 and newer.
+                    allowed_deps.extend([
+                        '/lib/libmd.so.1',
+                        '/usr/lib/libz.so.1',
+                        '/usr/lib/mps/libsqlite3.so',
+                        '/lib/libthread.so.1',
+                        ])
+            elif solaris_version == '11':
+                # Specific deps to add for Solaris 11.
+                allowed_deps.extend([
+                    '/lib/libcrypto.so.1.0.0',
+                    '/lib/libssl.so.1.0.0',
+                    '/lib/libz.so.1',
+                    '/usr/lib/libcrypt.so.1',
+                    '/usr/lib/libsqlite3.so.0',
+                    ])
     elif platform_system == 'hp-ux':
         # Specific deps for HP-UX 11.31, with full path.
         allowed_deps = [

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -254,17 +254,29 @@ def get_allowed_deps():
                 '/usr/local/opt/openssl/lib/libssl.1.0.0.dylib',
                 ])
     elif platform_system == 'freebsd':
-        # This is the list of specific deps for FreeBSD 10.x, with paths.
+        # This is the common list of deps for FreeBSD 10 and newer, with paths.
         allowed_deps = [
             '/lib/libc.so.7',
             '/lib/libcrypt.so.5',
-            '/lib/libcrypto.so.7',
             '/lib/libm.so.5',
             '/lib/libthr.so.3',
             '/lib/libutil.so.9',
             '/lib/libz.so.6',
-            '/usr/lib/libssl.so.7',
             ]
+        # On FreeBSD this can be: '10.3-RELEASE-p20', '11.0-RELEASE', etc.
+        freebsd_version = platform.release().split('.')[0]
+	if freebsd_version == '10':
+	    # Additional deps, specific for FreeBSD 10.
+	    allowed_deps.extend([
+		'/lib/libcrypto.so.7',
+		'/usr/lib/libssl.so.7',
+	    ])
+	else:
+	    # Additional deps, specific for FreeBSD 11 and maybe newer.
+	    allowed_deps.extend([
+		'/lib/libcrypto.so.8',
+		'/usr/lib/libssl.so.8',
+	    ])
     elif platform_system == 'openbsd':
         # This is the list of deps for OpenBSD 5.8 or newer, sans versions.
         allowed_deps = [


### PR DESCRIPTION
Scope
=====

FreeBSD 10 package doesn't work in FreeBSD 11.

Changes
=======

Stop trying to use `freebsd10` moniker and binaries for all FreeBSD versions.
Updated deps for FreeBSD 11.
Appended specific version in `paver.conf`.

**Drive-by changes**:
  * updated `paver.sh` and `paver.conf` from brink
  * fixed `chevah-brink` issue by merging with fixed branch
  * fixed cache validation issue in `paver.sh`.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests.
Check out new FreeBSD 11 build slave (only one compat test fails).