### PR TITLE
[#4299] HP-UX processor count fix.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -334,6 +334,9 @@ case "$ARCH" in
 esac
 if [ "${OS%hpux*}" = "" ]; then
     export PARALLEL="$JOBS"
+    # FIXME:4308:
+    # Parallel builds of GMP with more than 2 threads fail on HP-UX.
+    export PARALLEL=2
 else
     export MAKE="$MAKE -j${JOBS}"
 fi

--- a/functions.sh
+++ b/functions.sh
@@ -255,8 +255,8 @@ get_number_of_cpus() {
             CPUS=$(/usr/sbin/psrinfo -p)
             ;;
         hpux*)
-            # Only count physical cores. Tested on Itaniums.
-            CPUS=$(machinfo | grep proc | grep core | awk '{print $1}')
+            # This counts logical cores. Tested on Itaniums.
+            CPUS=$(ioscan -kFC processor | wc -l)
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)
             CPUS=$(sysctl -n hw.ncpu)

--- a/functions.sh
+++ b/functions.sh
@@ -252,24 +252,25 @@ get_number_of_cpus() {
             ;;
         aix*)
             # Physical CPUs on AIX 5.3/6.1/7.1, including (v)WPARs.
+            # CPU threads don't help us on PPC64 with this workload.
             CPUS=$(lparstat -i | grep ^"Active Physical CPUs" | cut -d\: -f2)
             ;;
         solaris*)
-            # Only count physical processors. SPARC has lots of threads lately,
-            # but they don't help much here. Tested on 10/11 on SPARC/AMD64/X86.
+            # Physical CPUs. SPARC has lots of threads lately, but they don't
+            # help much here. Tested on Solaris 10/11 on X86/AMD64/SPARC.
             CPUS=$(/usr/sbin/psrinfo -p)
             ;;
         hpux*)
-            # This counts logical cores. Tested on 11.31 running on Itaniums.
+            # Logical CPUs. Tested on HP-UX 11.31 running on Itaniums.
             CPUS=$(ioscan -kFC processor | wc -l)
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)
-            # Logical cores count.
+            # Logical CPUs.
             CPUS=$(sysctl -n hw.ncpu)
             ;;
         *)
             # Only Linux distros should be left.
-            # We count logical cores here.
+            # Logical CPUS.
             # Don't use lscpu/nproc or other stuff not present on older distros.
             CPUS=$(getconf _NPROCESSORS_ONLN)
             ;;

--- a/functions.sh
+++ b/functions.sh
@@ -247,18 +247,20 @@ wipe_manifest() {
 get_number_of_cpus() {
     case "$OS" in
         windows*)
+            # Logical CPUs (including hyper-threading) in Windows 2000 or newer.
             CPUS="$NUMBER_OF_PROCESSORS"
             ;;
         aix*)
-            # This works in AIX 5.3/6.1/7.1, including (v)WPARs.
-            CPUS=$(lparstat -i | grep ^"Maximum Physical CPUs" | cut -d\: -f2)
+            # Physical CPUs on AIX 5.3/6.1/7.1, including (v)WPARs.
+            CPUS=$(lparstat -i | grep ^"Active Physical CPUs" | cut -d\: -f2)
             ;;
         solaris*)
-            # Only count physical processors. Tested on SPARC, AMD64 and X86.
+            # Only count physical processors. SPARC has lots of threads lately,
+            # but they don't help much here. Tested on 10/11 on SPARC/AMD64/X86.
             CPUS=$(/usr/sbin/psrinfo -p)
             ;;
         hpux*)
-            # This counts logical cores. Tested on Itaniums.
+            # This counts logical cores. Tested on 11.31 running on Itaniums.
             CPUS=$(ioscan -kFC processor | wc -l)
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)
@@ -266,7 +268,8 @@ get_number_of_cpus() {
             CPUS=$(sysctl -n hw.ncpu)
             ;;
         *)
-            # Only Linux distros should be left. We count logical cores here.
+            # Only Linux distros should be left.
+            # We count logical cores here.
             # Don't use lscpu/nproc or other stuff not present on older distros.
             CPUS=$(getconf _NPROCESSORS_ONLN)
             ;;

--- a/functions.sh
+++ b/functions.sh
@@ -247,7 +247,7 @@ get_number_of_cpus() {
             CPUS="$NUMBER_OF_PROCESSORS"
             ;;
         aix*)
-            # This works in an AIX 5.3 vWPAR too.
+            # This works in AIX 5.3/6.1/7.1, including (v)WPARs.
             CPUS=$(lparstat -i | grep ^"Maximum Physical CPUs" | cut -d\: -f2)
             ;;
         solaris*)
@@ -255,7 +255,7 @@ get_number_of_cpus() {
             CPUS=$(/usr/sbin/psrinfo -p)
             ;;
         hpux*)
-            # Only count physical processors. Tested on Itanium.
+            # Only count physical cores. Tested on Itaniums.
             CPUS=$(machinfo | grep proc | grep core | awk '{print $1}')
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)

--- a/functions.sh
+++ b/functions.sh
@@ -241,6 +241,9 @@ wipe_manifest() {
 
 }
 
+#
+# Get number of CPUs on supported OS'es.
+#
 get_number_of_cpus() {
     case "$OS" in
         windows*)
@@ -259,10 +262,11 @@ get_number_of_cpus() {
             CPUS=$(ioscan -kFC processor | wc -l)
             ;;
         osx*|macos*|freebsd*|openbsd*|netbsd*)
+            # Logical cores count.
             CPUS=$(sysctl -n hw.ncpu)
             ;;
         *)
-            # Only Linux distros should be left.
+            # Only Linux distros should be left. We count logical cores here.
             # Don't use lscpu/nproc or other stuff not present on older distros.
             CPUS=$(getconf _NPROCESSORS_ONLN)
             ;;


### PR DESCRIPTION
Scope
=====

`machinfo | grep proc | grep core | awk '{print $1}'` only works as intended on HP-UX machines with a single physical processor.

Changes
=======

After some digging, I found a command that I was able to massage into giving us the **logical** number of CPUs. However, this seems to suit HP-UX hardware, as on Mosna I got slightly better compile times with 4 threads¹ (the number of logical CPUs) compared to 2 threads² (the number of physical CPUs), when compiling `python-package` without GMP.

1. https://chevah.com/buildbot/builders/python-package-hpux-dev/builds/0
2. https://chevah.com/buildbot/builders/python-package-hpux-dev/builds/1

**Drive-by changes**:
  * re-discovered a bug with compiling GMP on HP-UX with more than 2 threads. Filled it to be reported upstream on a hacking day or something
  * count active CPUs on AIX instead of maximum available
  * some more commenting for `get_number_of_cpus()`, to not have to remember all the related gory details.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run `test_review` which lately also includes `hpux-dev`: https://chevah.com/buildbot/builders/python-package-gk-review/builds/18.