### PR TITLE
[#4322] Alpine Linux support

### DIFF
--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.63.4 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca:alpine36@2.7.13.a3cb2b95'
+BASE_REQUIREMENTS='chevah-brink==0.66.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca:alpine36@2.7.13.8511f0a'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.63.4 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca'
+PYTHON_CONFIGURATION='default@2.7.13.25cf4cf:solaris11@2.7.13.c3d8a7d:solaris10@2.7.8.c3d8a7d:freebsd11@2.7.13.641bbdca:alpine36@2.7.13.a3cb2b95'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -590,6 +590,11 @@ detect_os() {
         elif [ -f /etc/arch-release ]; then
             # ArchLinux is a rolling distro, no version info available.
             OS="archlinux"
+        elif [ -f /etc/alpine-release ]; then
+            os_version_raw=$(cat /etc/alpine-release)
+            check_os_version "Alpine Linux" 3.6 \
+                "$os_version_raw" os_version_chevah
+            OS="alpine${os_version_chevah}"
         elif [ -f /etc/rpi-issue ]; then
             # Raspbian is a special case, a Debian unofficial derivative.
             if egrep -q ^'NAME="Raspbian GNU/Linux' /etc/os-release; then

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -22,6 +22,11 @@ elif [ "$os" = "SunOS" ]; then
     checker="ldd -L"
 elif [ "$os" = "HP-UX" ]; then
     checker="/usr/ccs/bin/ldd"
+elif [ "$os" = "Linux" ]; then
+    # objdump is more secure and portable than ldd, but more parsing is needed,
+    # as only lines that start with NEEDED are useful for deps checking.
+    # We use this as Alpine's ldd (from musl) goes nuts on some Python modules.
+    checker="objdump -p"
 fi
 
 # This portable invocation of find will get a raw list of linked libs

--- a/python-modules/chevah-python-test/get_binaries_deps.sh
+++ b/python-modules/chevah-python-test/get_binaries_deps.sh
@@ -23,10 +23,11 @@ elif [ "$os" = "SunOS" ]; then
 elif [ "$os" = "HP-UX" ]; then
     checker="/usr/ccs/bin/ldd"
 elif [ "$os" = "Linux" ]; then
-    # objdump is more secure and portable than ldd, but more parsing is needed,
-    # as only lines that start with NEEDED are useful for deps checking.
-    # We use this as Alpine's ldd (from musl) goes nuts on some Python modules.
-    checker="objdump -p"
+    if [ -f /etc/alpine-release ]; then
+        # musl's ldd has issues with some Python modules, so we use lddtree,
+        # which is forked from pax-utils and installed by default in Alpine.
+        checker="lddtree -l"
+    fi
 fi
 
 # This portable invocation of find will get a raw list of linked libs

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -32,8 +32,6 @@ def get_allowed_deps():
             'libssl.so',
             'libutil.so',
             'libz.so',
-            'linux-gate.so',
-            'linux-vdso.so',
             ]
         # Distro-specific deps to add. Now we may specify major versions too.
         if ('rhel' in chevah_os):
@@ -323,6 +321,9 @@ def get_actual_deps(script_helper):
     else:
         libs_deps = []
         for line in raw_deps:
+            if platform_system == 'linux' and not line.startswith('  NEEDED'):
+                # From objdump's output we want only lines starting with NEEDED.
+                continue
             if line.startswith('./') or not line:
                 # In some OS'es (AIX, HP-UX, OS X, BSDs), the output includes
                 # the examined binaries, and those lines start with "./".
@@ -342,6 +343,9 @@ def get_actual_deps(script_helper):
                 strings_to_ignore = ( 'Name', os.getcwd(), './', )
                 if dep.startswith(strings_to_ignore):
                     continue
+            elif platform_system == 'linux':
+                # objdump's lines starting with NEEDED list deps in 2th colon.
+                dep = line.split()[1]
             else:
                 # Usually, the first field in each line is the needed file name.
                 dep = line.split()[0]

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -93,6 +93,15 @@ def get_allowed_deps():
                 allowed_deps.extend([
                     '/usr/lib/arm-linux-gnueabihf/libarmmem.so',
                     ])
+        elif ('alpine' in chevah_os):
+            # This is a peculiar distro, so we start the list from scratch.
+            allowed_deps=([
+                'libc.musl-x86_64.so.1',
+                'libcrypto.so.41',
+                'libncursesw.so.6',
+                'libssl.so.43',
+                'libz.so.1',
+                ])
         else:
             # Debian 7 x64 (aka linux-x64) needs this for cffi.
             allowed_deps.extend([

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -199,8 +199,9 @@ chevahbs_install() {
             ;;
         *)
             if [ "${OS%alpine*}" = "" ]; then
-                # EMUTRAMP required for full functionality with a grsec kernel.
-                execute paxmark -E python
+                # EMUTRAMP required for full functionality under a grsec kernel.
+                # Don't use "paxmark", file attributes will be lost when tar'ed.
+                execute paxctl -cE python
             fi
             execute $MAKE install DESTDIR=$INSTALL_FOLDER
             ;;

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -198,6 +198,10 @@ chevahbs_install() {
                 sed "s|# utf_8 codec|# utf_8 codec\n    'cp65001'            : 'utf_8',|" < $destination/lib/encodings/aliases.old > $destination/lib/encodings/aliases.py
             ;;
         *)
+            if [ "${OS%alpine*}" = "" ]; then
+                # EMUTRAMP required for full functionality with a grsec kernel.
+                execute paxmark -E python
+            fi
             execute $MAKE install DESTDIR=$INSTALL_FOLDER
             ;;
     esac


### PR DESCRIPTION
Scope
=====

`paver.sh` tries to use a generic Linux package in Alpine, but that fails.


Changes
=======

Identify Alpine Linux.
Check for version 3.6 or newer.
Use `lddtree -l`, as musl's ldd has issues with some Python modules.
Updated deps to accommodate this peculiar little distro.
Mark resulting `python` binary with `paxctl` for EMUTRAMP, otherwise grsec kernels will kill it, as default behaviour violates MPROTECT.
Updated `paver.conf` accordingly.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the tests.
Run a server test with latest package, eg. https://chevah.com/buildbot/builders/server-alpine/builds/25
