### PR TITLE
[#4318] Detect Ubuntu without LBS tools.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -593,7 +593,7 @@ detect_os() {
         elif [ -f /etc/os-release ]; then
             linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
             os_version_raw=$(\
-                grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
+                grep ^'VERSION_ID=' /etc/os-release | cut -d'=' -f2)
             case "$linux_distro" in
                 "ubuntu")
                     check_os_version "Ubuntu Long-term Support" 14.04 \

--- a/paver.sh
+++ b/paver.sh
@@ -595,30 +595,28 @@ detect_os() {
             check_os_version "Alpine Linux" 3.6 \
                 "$os_version_raw" os_version_chevah
             OS="alpine${os_version_chevah}"
-        elif [ -f /etc/rpi-issue ]; then
-            # Raspbian is a special case, a Debian unofficial derivative.
-            if egrep -q ^'NAME="Raspbian GNU/Linux' /etc/os-release; then
-                os_version_raw=$(\
-                    grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
-                check_os_version "Raspbian GNU/Linux" 7 \
-                    "$os_version_raw" os_version_chevah
-                OS="raspbian${os_version_chevah}"
-            fi
         elif [ -f /etc/os-release ]; then
             linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
-            os_version_raw=$(grep ^VERSION_ID= /etc/os-release \
-                | cut -d'=' -f2 | cut -d'"' -f2)
-            if [ "$linux_distro" = "ubuntu" ]; then
-                check_os_version "Ubuntu Long-term Support" 14.04 \
-                    "$os_version_raw" os_version_chevah
-                # Only Long-term Support versions are officially endorsed, thus
-                # $os_version_chevah should end in 04, and the first two digits
-                # should represent an even year.
-                if [ ${os_version_chevah%%04} != ${os_version_chevah} -a \
-                    $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
-                    OS="ubuntu${os_version_chevah}"
-                fi
-            fi
+            os_version_raw=$(\
+                grep ^'VERSION_ID=' /etc/os-release | cut -d'"' -f2)
+            case "$linux_distro" in
+                "ubuntu")
+                    check_os_version "Ubuntu Long-term Support" 14.04 \
+                        "$os_version_raw" os_version_chevah
+                    # Only Long-term Support versions are supported,
+                    # thus $os_version_chevah should end in 04,
+                    # and the first two digits should represent an even year.
+                    if [ ${os_version_chevah%%04} != ${os_version_chevah} -a \
+                        $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
+                        OS="ubuntu${os_version_chevah}"
+                    fi
+                    ;;
+                "raspbian")
+                    check_os_version "Raspbian GNU/Linux" 7 \
+                        "$os_version_raw" os_version_chevah
+                    OS="raspbian${os_version_chevah}"
+                    ;;
+            esac
         fi
     elif [ "${OS}" = "darwin" ]; then
         ARCH=$(uname -m)

--- a/paver.sh
+++ b/paver.sh
@@ -478,6 +478,7 @@ check_os_version() {
     # supported for the current OS and the current detected version.
     # The fourth parameter is used to return through eval the relevant numbers
     # for naming the Python package for the current OS, as detailed above.
+    # Beware, this function is full of bash'isms.
     local name_fancy="$1"
     local version_good="$2"
     local version_raw="$3"
@@ -486,6 +487,12 @@ check_os_version() {
     local flag_supported='good_enough'
     local version_raw_array
     local version_good_array
+
+    if [[ $version_raw =~ [^[:digit:]\.] ]]; then
+        echo "Unparsed OS version should only have numbers and periods, but:"
+        echo "    \$version_raw=$version_raw"
+        exit 12
+    fi
 
     # Using '.' as a delimiter, populate the version_raw_* arrays.
     IFS=. read -a version_raw_array <<< "$version_raw"
@@ -595,10 +602,10 @@ detect_os() {
             source /etc/os-release
             linux_distro="$ID"
             os_version_raw="$VERSION_ID"
-            distro_name="$NAME"
+            distro_fancy_name="$NAME"
             case "$linux_distro" in
                 "ubuntu")
-                    check_os_version "$distro_name" 14.04 \
+                    check_os_version "$distro_fancy_name" 14.04 \
                         "$os_version_raw" os_version_chevah
                     # Only Long-term Support versions are supported,
                     # thus $os_version_chevah should end in 04,
@@ -612,12 +619,12 @@ detect_os() {
                     fi
                     ;;
                 "raspbian")
-                    check_os_version "$distro_name" 7 \
+                    check_os_version "$distro_fancy_name" 7 \
                         "$os_version_raw" os_version_chevah
                     OS="raspbian${os_version_chevah}"
                     ;;
                 "alpine")
-                    check_os_version "$distro_name" 3.6 \
+                    check_os_version "$distro_fancy_name" 3.6 \
                         "$os_version_raw" os_version_chevah
                     OS="alpine${os_version_chevah}"
                     ;;

--- a/paver.sh
+++ b/paver.sh
@@ -604,11 +604,12 @@ detect_os() {
                     "$os_version_raw" os_version_chevah
                 OS="raspbian${os_version_chevah}"
             fi
-        elif [ $(command -v lsb_release) ]; then
-            lsb_release_id=$(lsb_release -is)
-            os_version_raw=$(lsb_release -rs)
-            if [ $lsb_release_id = Ubuntu ]; then
-                check_os_version "Ubuntu Long-term Support" 10.04 \
+        elif [ -f /etc/os-release ]; then
+            linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
+            os_version_raw=$(grep ^VERSION_ID= /etc/os-release \
+                | cut -d'=' -f2 | cut -d'"' -f2)
+            if [ "$linux_distro" = "ubuntu" ]; then
+                check_os_version "Ubuntu Long-term Support" 14.04 \
                     "$os_version_raw" os_version_chevah
                 # Only Long-term Support versions are officially endorsed, thus
                 # $os_version_chevah should end in 04, and the first two digits

--- a/paver.sh
+++ b/paver.sh
@@ -590,11 +590,6 @@ detect_os() {
         elif [ -f /etc/arch-release ]; then
             # ArchLinux is a rolling distro, no version info available.
             OS="archlinux"
-        elif [ -f /etc/alpine-release ]; then
-            os_version_raw=$(cat /etc/alpine-release)
-            check_os_version "Alpine Linux" 3.6 \
-                "$os_version_raw" os_version_chevah
-            OS="alpine${os_version_chevah}"
         elif [ -f /etc/os-release ]; then
             linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
             os_version_raw=$(\
@@ -618,6 +613,11 @@ detect_os() {
                     check_os_version "Raspbian GNU/Linux" 7 \
                         "$os_version_raw" os_version_chevah
                     OS="raspbian${os_version_chevah}"
+                    ;;
+                "alpine")
+                    check_os_version "Alpine Linux" 3.6 \
+                        "$os_version_raw" os_version_chevah
+                    OS="alpine${os_version_chevah}"
                     ;;
             esac
         fi

--- a/paver.sh
+++ b/paver.sh
@@ -592,12 +592,13 @@ detect_os() {
             # Beware that there's no version to get from /etc/os-release either!
             OS="archlinux"
         elif [ -f /etc/os-release ]; then
-            linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
-            os_version_raw=$(\
-                grep ^'VERSION_ID=' /etc/os-release | cut -d'=' -f2)
+            source /etc/os-release
+            linux_distro="$ID"
+            os_version_raw="$VERSION_ID"
+            distro_name="$NAME"
             case "$linux_distro" in
                 "ubuntu")
-                    check_os_version "Ubuntu Long-term Support" 14.04 \
+                    check_os_version "$distro_name" 14.04 \
                         "$os_version_raw" os_version_chevah
                     # Only Long-term Support versions are supported,
                     # thus $os_version_chevah should end in 04,
@@ -611,12 +612,12 @@ detect_os() {
                     fi
                     ;;
                 "raspbian")
-                    check_os_version "Raspbian GNU/Linux" 7 \
+                    check_os_version "$distro_name" 7 \
                         "$os_version_raw" os_version_chevah
                     OS="raspbian${os_version_chevah}"
                     ;;
                 "alpine")
-                    check_os_version "Alpine Linux" 3.6 \
+                    check_os_version "$distro_name" 3.6 \
                         "$os_version_raw" os_version_chevah
                     OS="alpine${os_version_chevah}"
                     ;;

--- a/paver.sh
+++ b/paver.sh
@@ -478,7 +478,6 @@ check_os_version() {
     # supported for the current OS and the current detected version.
     # The fourth parameter is used to return through eval the relevant numbers
     # for naming the Python package for the current OS, as detailed above.
-    # Beware, this function is full of bash'isms.
     local name_fancy="$1"
     local version_good="$2"
     local version_raw="$3"

--- a/paver.sh
+++ b/paver.sh
@@ -588,7 +588,8 @@ detect_os() {
                 fi
             fi
         elif [ -f /etc/arch-release ]; then
-            # ArchLinux is a rolling distro, no version info available.
+            # Arch Linux is a rolling distro, no version info available.
+            # Beware that there's no version to get from /etc/os-release either!
             OS="archlinux"
         elif [ -f /etc/os-release ]; then
             linux_distro=$(grep ^ID= /etc/os-release | cut -d'=' -f2)

--- a/paver.sh
+++ b/paver.sh
@@ -609,6 +609,9 @@ detect_os() {
                     if [ ${os_version_chevah%%04} != ${os_version_chevah} -a \
                         $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
                         OS="ubuntu${os_version_chevah}"
+                    else
+                        echo "Unsupported Ubuntu, please use an LTS version."
+                        exit 15
                     fi
                     ;;
                 "raspbian")

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -142,7 +142,6 @@ def get_allowed_deps():
             allowed_deps = [
                 '/lib/64/libc.so.1',
                 '/lib/64/libdl.so.1',
-                '/lib/64/libintl.so.1',
                 '/lib/64/libm.so.2',
                 '/lib/64/libnsl.so.1',
                 '/lib/64/libsocket.so.1',
@@ -184,7 +183,6 @@ def get_allowed_deps():
             allowed_deps = [
                 '/lib/libc.so.1',
                 '/lib/libdl.so.1',
-                '/lib/libintl.so.1',
                 '/lib/libm.so.2',
                 '/lib/libnsl.so.1',
                 '/lib/libsocket.so.1',
@@ -294,7 +292,7 @@ def get_allowed_deps():
             '/usr/lib/libc.so',
             '/usr/lib/libcrypto.so',
             '/usr/lib/libm.so',
-            '/usr/lib/libncursesw.so.14.0',
+            '/usr/lib/libncursesw.so',
             '/usr/lib/libpthread.so',
             '/usr/lib/libssl.so',
             '/usr/lib/libutil.so',
@@ -310,7 +308,6 @@ def get_allowed_deps():
             '/usr/lib/libcrypto.so.8',
             '/usr/lib/libcurses.so.7',
             '/usr/lib/libgcc_s.so.1',
-            '/usr/lib/libintl.so.1',
             '/usr/lib/libm.so.0',
             '/usr/lib/libpthread.so.1',
             '/usr/lib/libssl.so.10',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -112,27 +112,39 @@ def get_allowed_deps():
                 'libgcc_s.so.1',
                 ])
     elif platform_system == 'aix':
-        # This is the standard list of deps for AIX 5.3. Some of the links
-        # for these libs moved in newer versions from '/usr/lib/' to '/lib/'.
+        # List of deps with full paths for AIX 5.3 with OpenSSL 1.0.2k.
+        # These deps are common to AIX 6.1 and 7.1 as well. 
         allowed_deps = [
+            '/lib/libbsd.a(shr.o)',
+            '/lib/libc.a(pse.o)',
+            '/lib/libc.a(shr.o)',
+            '/lib/libcrypt.a(shr.o)',
+            '/lib/libcrypto.a(libcrypto.so.1.0.0)',
+            '/lib/libcrypto.so',
+            '/lib/libnsl.a(shr.o)',
+            '/lib/libpthreads.a(shr.o)',
+            '/lib/libpthreads.a(shr_comm.o)',
+            '/lib/libpthreads_compat.a(shr.o)',
+            '/lib/libssl.so',
+            '/lib/libtli.a(shr.o)',
+            '/lib/libz.a(libz.so.1)',
+            '/usr/lib/libc.a(shr.o)',
+            '/usr/lib/libcrypt.a(shr.o)',
+            '/usr/lib/libcrypto.a(libcrypto.so.1.0.0)',
+            '/usr/lib/libcrypto.so',
+            '/usr/lib/libdl.a(shr.o)',
+            '/usr/lib/libpthreads.a(shr_comm.o)',
+            '/usr/lib/libpthreads.a(shr_xpg5.o)',
+            '/usr/lib/libssl.so',
             '/unix',
-            'libbsd.a',
-            'libc.a',
-            'libcrypt.a',
-            'libcrypto.a',
-            'libdl.a',
-            'libnsl.a',
-            'libpthreads.a',
-            'libpthreads_compat.a',
-            'libssl.a',
-            'libtli.a',
-            'libz.a',
-            ]
+             ]
         # sys.platform could be 'aix5', 'aix6' etc.
         aix_version = int(sys.platform[-1])
         if aix_version >= 6:
+            # Specific deps to add for AIX 6.1 and 7.1.
             allowed_deps.extend([
-                'libthread.a',
+                '/lib/libpthreads.a(shr_xpg5.o)',
+                '/lib/libthread.a(shr.o)',
                 ])
     elif platform_system == 'sunos':
         # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -113,7 +113,7 @@ def get_allowed_deps():
                 ])
     elif platform_system == 'aix':
         # List of deps with full paths for AIX 5.3 with OpenSSL 1.0.2k.
-        # These deps are common to AIX 6.1 and 7.1 as well. 
+        # These deps are common to AIX 6.1 and 7.1 as well.
         allowed_deps = [
             '/lib/libbsd.a(shr.o)',
             '/lib/libc.a(pse.o)',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -137,7 +137,7 @@ def get_allowed_deps():
             '/usr/lib/libpthreads.a(shr_xpg5.o)',
             '/usr/lib/libssl.so',
             '/unix',
-             ]
+            ]
         # sys.platform could be 'aix5', 'aix6' etc.
         aix_version = int(sys.platform[-1])
         if aix_version >= 6:

--- a/src/python/disabled_modules.patch
+++ b/src/python/disabled_modules.patch
@@ -1,7 +1,7 @@
 diff -ur setup.py setup.py
 --- setup.py
 +++ setup.py
-@@ -33,7 +33,18 @@ host_platform = get_platform()
+@@ -33,7 +33,19 @@ host_platform = get_platform()
  COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
  
  # This global variable is used to hold the list of modules to be disabled.
@@ -10,6 +10,7 @@ diff -ur setup.py setup.py
 +    '_bsddb',
 +    '_curses',
 +    '_curses_panel',
++    '_locale',
 +    '_sqlite3',
 +    '_tkinter',
 +    'bz2',

--- a/src/python/readline_libedit.patch
+++ b/src/python/readline_libedit.patch
@@ -991,7 +991,7 @@ diff -ru pyconfig.h.in pyconfig.h.in
 diff -ru setup.py setup.py
 --- setup.py	2017-03-16 19:04:35.989975569 +0200
 +++ setup.py	2017-03-16 19:05:22.690158008 +0200
-@@ -42,7 +42,6 @@
+@@ -43,7 +43,6 @@
      'bz2',
      'dbm',
      'gdbm',
@@ -999,7 +999,7 @@ diff -ru setup.py setup.py
      'sunaudiodev',
      ]
  
-@@ -734,9 +733,17 @@
+@@ -735,9 +734,17 @@
              missing.extend(['imageop'])
  
          # readline
@@ -1018,7 +1018,7 @@ diff -ru setup.py setup.py
          # Determine if readline is already linked against curses or tinfo.
          if do_readline and find_executable('ldd'):
              fp = os.popen("ldd %s" % do_readline)
-@@ -787,7 +794,7 @@
+@@ -788,7 +795,7 @@
              else:
                  readline_extra_link_args = ()
  


### PR DESCRIPTION
Scope
=====

Ubuntu detection in `paver.sh` fails if `lsb-release` package missing. Detected on Pine64 after removing `python3*` packages.

Changes
=======

Refactored Ubuntu detection to use `/etc/os-release`, present in Ubuntu 14.04 and newer, the only releases currently supported.

When older supported Linux distros (without `/etc/os-release`) are phased out (RHEL 6 and SLES 10&11), we could move to using `/etc/os-release` exclusively for distro detection in Linux (except for Arch, which is a rolling release distro and thus has no version info in that file).. 

**Drive-by changes**:
 * use `/etc/os-release` for Raspbian and Alpine Linux too
 * never build the `_locale` Python module to avoid depending on `libintl`, the GNU gettext libs
 * updated AIX deps with full paths after installing latest OpenSSL libs from IBM
 * check that `$os_version_raw` only contains digits and periods.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the automated tests, eg. https://chevah.com/buildbot/builders/python-package-gk-review/builds/30
Remove `lsb*` packages and check `./paver.sh detect_os` on an Ubuntu system.
Force an unexpected character in `$os_version_raw` to test new check.
