### PR TITLE
[#4425] Use a fixed length for the git rev in the version.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -24,7 +24,7 @@ PIP_VERSION="9.0.1"
 SETUPTOOLS_VERSION="20.3.1"
 
 # Git revision to inject into Python's sys.version string through chevahbs.
-PYTHON_PACKAGE_VERSION=$(git rev-parse --short=4 HEAD)
+PYTHON_PACKAGE_VERSION=$(git rev-parse --short=8 HEAD)
 # The ID of the redistributable version used on Windows.
 REDISTRIBUTABLE_VERSION="9.00.30729.6161"
 

--- a/chevah_build
+++ b/chevah_build
@@ -24,7 +24,7 @@ PIP_VERSION="9.0.1"
 SETUPTOOLS_VERSION="20.3.1"
 
 # Git revision to inject into Python's sys.version string through chevahbs.
-PYTHON_PACKAGE_VERSION=$(git rev-parse --short HEAD)
+PYTHON_PACKAGE_VERSION=$(git rev-parse --short=4 HEAD)
 # The ID of the redistributable version used on Windows.
 REDISTRIBUTABLE_VERSION="9.00.30729.6161"
 
@@ -204,7 +204,7 @@ case $OS in
             # We favour the BSD-flavoured "install" over the default one.
             # "ar", "nm" and "ld" are included by default in the same path.
             export PATH=/usr/ccs/bin/:$PATH
-            # sqlite3 lib location in all Solaris'es (incl. 10s10 for Sparc).
+            # sqlite3 lib location in all 10uX versions, including early ones.
             if [ "${ARCH%64}" = "$ARCH" ]; then
                 export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
             else

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -595,6 +595,10 @@ def main():
                                  "\tBin ver: {0}".format(bin_ver) + "\n"
                                  "\tGit rev: {0}".format(git_rev) + "\n")
                 exit_code = 118
+            if len(bin_ver) != 8:
+                sys.stderr.write("Bad length for binary version, expected 8!\n"
+                                 "\tBin ver: {0}".format(bin_ver) + "\n")
+                exit_code = 119
 
         try:
             import _scandir

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -583,7 +583,7 @@ def main():
 
         # Check for the git revision in Python's sys.version on Linux and Unix.
         try:
-            git_rev_cmd = ['git', 'rev-parse', '--short', 'HEAD']
+            git_rev_cmd = ['git', 'rev-parse', '--short=4', 'HEAD']
             git_rev = subprocess.check_output(git_rev_cmd).strip()
         except:
             sys.stderr.write("Couldn't get the git rev for the current tree.\n")

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -583,7 +583,7 @@ def main():
 
         # Check for the git revision in Python's sys.version on Linux and Unix.
         try:
-            git_rev_cmd = ['git', 'rev-parse', '--short=4', 'HEAD']
+            git_rev_cmd = ['git', 'rev-parse', '--short=8', 'HEAD']
             git_rev = subprocess.check_output(git_rev_cmd).strip()
         except:
             sys.stderr.write("Couldn't get the git rev for the current tree.\n")


### PR DESCRIPTION
Scope
=====

With latest production Python packages, some of the packages use a git rev of 7 characters and others use 8 characters. This leads to broken tests, as the used length is not consistent among similar build slaves (being dependent of `core.abbrev` conf variable according to `git-rev-parse(1)`).


Changes
=======

Force the length of 8 for consistency.
Test the length of the git rev set in the binary.

**Drive-by change**:
 * really minor comment clarification in regards to `sqlite` libs to link to in Solaris 10.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the automated tests, eg: https://chevah.com/buildbot/builders/python-package-gk-review/builds/39