### PR TITLE
[#4437] Minor /etc/os-release fixes.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -600,10 +600,10 @@ detect_os() {
         elif [ -f /etc/os-release ]; then
             source /etc/os-release
             linux_distro="$ID"
-            os_version_raw="$VERSION_ID"
             distro_fancy_name="$NAME"
             case "$linux_distro" in
                 "ubuntu")
+                    os_version_raw="$VERSION_ID"
                     check_os_version "$distro_fancy_name" 14.04 \
                         "$os_version_raw" os_version_chevah
                     # Only Long-term Support versions are supported,
@@ -618,11 +618,13 @@ detect_os() {
                     fi
                     ;;
                 "raspbian")
+                    os_version_raw="$VERSION_ID"
                     check_os_version "$distro_fancy_name" 7 \
                         "$os_version_raw" os_version_chevah
                     OS="raspbian${os_version_chevah}"
                     ;;
                 "alpine")
+                    os_version_raw="$VERSION_ID"
                     check_os_version "$distro_fancy_name" 3.6 \
                         "$os_version_raw" os_version_chevah
                     OS="alpine${os_version_chevah}"

--- a/paver.sh
+++ b/paver.sh
@@ -613,8 +613,7 @@ detect_os() {
                         $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
                         OS="ubuntu${os_version_chevah}"
                     else
-                        echo "Unsupported Ubuntu, please use an LTS version."
-                        exit 15
+                        echo "Unsupported Ubuntu, using generic Linux binaries!"
                     fi
                     ;;
                 "raspbian")


### PR DESCRIPTION
Scope
=====

`VERSION_ID` is sometimes missing from `/etc/os-release`.  For example on my old Gentoo installation that I keep around at home. Result:
```
$ ./paver.sh
./paver.sh: line 603: VERSION_ID: unbound variable
```

Also, Ubuntu non-LTS versions are now rejected, while we used to equate them with generic Linux before introducing support for `/etc/os-release`.


Changes
=======

Only use `VERSION_ID` from `/etc/os-release` on supported distros, for now: Ubuntu, Raspbian and Alpine. This variable is not set on some rolling-release distros according to https://www.freedesktop.org/software/systemd/man/os-release.html.

Use generic Linux binaries on non-LTS Ubuntu versions.

How to try and test the changes
===============================

reviewers: @adiroiban

Please review the changes.
Run `paver.sh` on a rolling-release distro such as Gentoo.
Run `paver.sh` on a non-LTS Ubuntu version.
Run the automated tests.