### PR TITLE
[#4483] Functional pysqlite2 module on Solaris 10 SPARC.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -180,6 +180,12 @@ case $OS in
         if [ "$OS" = "solaris10u3" ]; then
             # pip doesn't like the included zlib from this old Solaris release.
             export BUILD_ZLIB="yes"
+            # sqlite libs are to be found in an unusual place.
+            if [ "${ARCH%64}" = "$ARCH" ]; then
+                export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
+            else
+                export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
+            fi
         fi
         # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then
@@ -206,12 +212,6 @@ case $OS in
             # We favour the BSD-flavoured "install" over the default one.
             # "ar", "nm" and "ld" are included by default in the same path.
             export PATH=/usr/ccs/bin/:$PATH
-            # sqlite3 lib location in all 10uX versions, including early ones.
-            if [ "${ARCH%64}" = "$ARCH" ]; then
-                export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
-            else
-                export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
-            fi
         fi
         # cffi modules are not ready yet on Solaris.
         export BUILD_CFFI="no"
@@ -680,7 +680,7 @@ initialize_python_module(){
                 cp $INSTALL_FOLDER/lib/$PYTHON_VERSION/config/* Modules
                 extra_args=""
                 if [ "${OS%solaris10*}" = "" ]; then
-                    # Needed to build pyOpenSSL in Solaris 10.
+                    # To link pyOpenSSL to included OpenSSL 0.9.7 libs.
                     extra_args="$extra_args -I/usr/sfw/include"
                     if [ "${ARCH%64}" = "$ARCH" ]; then
                         extra_args="$extra_args -L/usr/sfw/lib"

--- a/chevah_build
+++ b/chevah_build
@@ -180,12 +180,8 @@ case $OS in
         if [ "$OS" = "solaris10u3" ]; then
             # pip doesn't like the included zlib from this old Solaris release.
             export BUILD_ZLIB="yes"
-            # sqlite libs are to be found in an unusual place.
-            if [ "${ARCH%64}" = "$ARCH" ]; then
-                export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
-            else
-                export LDFLAGS="$LDFLAGS -L/usr/lib/mps/64 -R/usr/lib/mps/64"
-            fi
+            # SQLite libs dir on 10u3 x86.
+            export LDFLAGS="$LDFLAGS -L/usr/lib/mps -R/usr/lib/mps"
         fi
         # Here's where the system-included GCC is to be found.
         if [ "${CC}" = "gcc" ]; then

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -570,9 +570,9 @@ def main():
 
         try:
             import pysqlite2
-            pysqlite2
+            from pysqlite2 import dbapi2 as sqlite_driver
         except:
-            sys.stderr.write('"pysqlite2" missing.\n')
+            sys.stderr.write('"pysqlite2" missing or broken.\n')
             exit_code = 6
 
         try:

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -554,10 +554,11 @@ def main():
             sys.stderr.write('"ctypes - windll" missing.\n')
             exit_code = 15
         try:
-            import sqlite3
-            sqlite3
+            from sqlite3 import dbapi2 as sqlite
+            print 'sqlite3 %s - sqlite %s' % (
+                    sqlite.version, sqlite.sqlite_version)
         except:
-            sys.stderr.write('"sqlite3" missing.\n')
+            sys.stderr.write('"sqlite3" missing or broken.\n')
             exit_code = 6
 
     else:
@@ -570,8 +571,9 @@ def main():
             exit_code = 5
 
         try:
-            import pysqlite2
-            from pysqlite2 import dbapi2 as sqlite_driver
+            from pysqlite2 import dbapi2 as sqlite
+            print 'pysqlite2 %s - sqlite %s' % (
+                    sqlite.version, sqlite.sqlite_version)
         except:
             sys.stderr.write('"pysqlite2" missing or broken.\n')
             exit_code = 6

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -171,8 +171,9 @@ def get_allowed_deps():
                     '/lib/64/librt.so.1',
                     '/lib/64/libthread.so.1',
                     '/usr/lib/64/libcrypt_i.so.1',
+                    '/usr/lib/64/libsqlite3.so.0',
                     '/usr/lib/64/libz.so.1',
-                    '/usr/lib/mps/64/libsqlite3.so',
+                    '/usr/lib/amd64/libc.so.1',
                     '/usr/sfw/lib/64/libcrypto.so.0.9.7',
                     '/usr/sfw/lib/64/libssl.so.0.9.7',
                     ])
@@ -226,9 +227,9 @@ def get_allowed_deps():
                     # Specific deps for Solaris 10u8 and newer.
                     allowed_deps.extend([
                         '/lib/libmd.so.1',
-                        '/usr/lib/libz.so.1',
-                        '/usr/lib/mps/libsqlite3.so',
                         '/lib/libthread.so.1',
+                        '/usr/lib/libsqlite3.so.0',
+                        '/usr/lib/libz.so.1',
                         ])
             elif solaris_version == '11':
                 # Specific deps to add for Solaris 11.


### PR DESCRIPTION
Scope
=====

It looks like sqlite is no longer working on solaris 10 sparc.


Changes
=======

Use a test that actually breaks when `pysqlite2` module is broken.
Link to `sqlite` libs in `/usr/lib/mps` only on Solaris 10 versions up to u7.
Output the version of both SQLite system lib and the corresponding Python module.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests, eg. https://chevah.com/buildbot/builders/python-package-group-all/builds/4