### PR TITLE
[#4438] Use /etc/os-release for Arch Linux too.

### DIFF
--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.66.0 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.14.8f78f41f:solaris10@2.7.8.8f78f41f'
+BASE_REQUIREMENTS='chevah-brink==0.67.4 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.14.620df8b0:solaris10@2.7.8.62700b56'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -593,10 +593,6 @@ detect_os() {
                     OS="sles11sm"
                 fi
             fi
-        elif [ -f /etc/arch-release ]; then
-            # Arch Linux is a rolling distro, no version info available.
-            # Beware that there's no version to get from /etc/os-release either!
-            OS="archlinux"
         elif [ -f /etc/os-release ]; then
             source /etc/os-release
             linux_distro="$ID"
@@ -627,6 +623,10 @@ detect_os() {
                     check_os_version "$distro_fancy_name" 3.6 \
                         "$os_version_raw" os_version_chevah
                     OS="alpine${os_version_chevah}"
+                    ;;
+                "arch")
+                    # Arch Linux is a rolling distro, no version info available.
+                    OS="archlinux"
                     ;;
             esac
         fi


### PR DESCRIPTION
Scope
=====

Now that we don't use VERSION_ID for all distros where we count on `/etc/os-release`, Arch as rolling-release distro should fit among them as well.

Changes
=======

Stop using `/etc/arch-release` in favour of `/etc/os-release`.

**Drive-by change**:
  * updated `paver.conf`

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Check that Arch is detected properly by `paver.sh`.
Run the automated tests.