### PR TITLE
[#4308] Limit parallel builds on HP-UX for GMP only.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build/
-dist/
-DEFAULT_VALUES
-build-*/
-cache
+/build/
+/dist/
+/DEFAULT_VALUES
+/build-*
+/cache

--- a/chevah_build
+++ b/chevah_build
@@ -165,7 +165,7 @@ case $OS in
                 export CFLAGS="$CFLAGS -qmaxmem=-1 -q64"
             fi
         fi
-        # libedit requirers __STDC_ISO_10646__.
+        # libedit requires __STDC_ISO_10646__.
         export BUILD_LIBEDIT="no"
         # On AIX cffi based modules are not ported yet.
         export BUILD_CFFI="no"
@@ -225,7 +225,7 @@ case $OS in
         # Native make is needed for parallel builds.
         export MAKE="make -P"
         export BUILD_ZLIB="yes"
-        # libedit requirers __STDC_ISO_10646__.
+        # libedit requires __STDC_ISO_10646__.
         export BUILD_LIBEDIT="no"
         export BUILD_CFFI="no"
         PIP_LIBRARIES=""
@@ -328,9 +328,6 @@ case "$ARCH" in
 esac
 if [ "${OS%hpux*}" = "" ]; then
     export PARALLEL="$JOBS"
-    # FIXME:4308:
-    # Parallel builds of GMP with more than 2 threads fail on HP-UX.
-    export PARALLEL=2
 else
     export MAKE="$MAKE -j${JOBS}"
 fi

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -24,6 +24,10 @@ chevahbs_configure() {
         raspbian*)
             CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf --with-pic"
         ;;
+        hpux*)
+            # GMP parallel builds fail on HP-UX when using more than 2 threads.
+            export PARALLEL=2
+        ;;
     esac
     execute ./configure --prefix="" $CONF_OPTS
 }


### PR DESCRIPTION
Scope
=====

Parallel builds of GMP fail on HP-UX when using more than 2 threads… Eg. https://chevah.com/buildbot/builders/python-package-hpux-dev/builds/3/steps/build/logs/stdio:

```
Making target"mpn/mp_bases.lo"
	/bin/sh ./libtool  --tag=CC    --mode=compile /opt/aCC/bin/cc -w -DHAVE_CONFIG_H  -I.  -D__GMP_WITHIN_GMP    +O2 -c -o mpn/mp_bases.lo mpn/mp_bases.c
libtool: compile:  /opt/aCC/bin/cc -w -DHAVE_CONFIG_H -I. -D__GMP_WITHIN_GMP +O2 -c mpn/mp_bases.c -o mpn/mp_bases.o
Making target"config.h"
At end of source: error #2018: expected a ")"

"mpn/mp_bases.c", line 185: error #2274: improperly terminated macro invocation
    /* 173 */ { 8, CNST_LIMB(0x226ef7776aa7fd29), CNST_LIMB(0x
                                                  ^

At end of source: error #2029: expected an expression

At end of source: error #2067: expected a "}"

At end of source: error #2067: expected a "}"

At end of source: error #2065: expected a ";"

6 errors detected in the compilation of "mpn/mp_bases.c".
```


Changes
=======

As GMP author has shown no interest in fixing issues with the native `make` in HP-UX, we limit the number of parallel builds to 2 on HP-UX when building GMP.

**Drive-by fixes**:
  * improve `.gitignore`
  * fixed a couple of spelling errors.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Build it on HP-UX.
Run the automated tests.