### PR TITLE
[#4712] No more package management at build time.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -332,30 +332,26 @@ else
     export MAKE="$MAKE -j${JOBS}"
 fi
 
-#
-# Install OS package required to build Python.
-#
-install_dependencies() {
 
-    packages='packages-not-defined'
-    install_command='install-command-not-defined'
-    check_command='check-command-not-defined'
+#
+# Check for OS packages required to build Python.
+#
+check_dependencies() {
+
+    missing_packages=""
 
     case $OS in
         # Debian-derived distros are similar in this regard.
         ubuntu*|raspbian*)
             packages=$DEBIAN_PACKAGES
-            install_command='sudo apt-get --assume-yes install'
             check_command='dpkg --status'
         ;;
         rhel*)
             packages=$RHEL_PACKAGES
-            install_command='sudo yum -y install'
             check_command='rpm --query'
         ;;
         sles*)
             packages=$SLES_PACKAGES
-            install_command='sudo zypper --non-interactive install -l'
             check_command='rpm --query'
         ;;
         macos*)
@@ -368,89 +364,31 @@ install_dependencies() {
                 exit 102
             fi
             packages=''
-            install_command=''
-            check_command=''
         ;;
         *)
             packages=''
-            install_command=''
-            check_command=''
         ;;
     esac
 
-    # We install one package after another since some package managers
-    # (I am looking at you yum) will exit with 0 exit code if at least
-    # one package was successfully installed.
     if [ -n "$packages" ]; then
         echo "Checking for packages to be installed..."
         for package in $packages ; do
             echo "Checking if $package is installed..."
             $check_command $package
             if [ $? -ne 0 ]; then
-                echo "Installing $package using ${install_command}..."
-                execute $install_command $package \
-                    && INSTALLED_PACKAGES="$INSTALLED_PACKAGES $package"
+                echo "Missing required dependency: $package"
+                missing_packages="$missing_packages $package"
             fi
         done
     fi
-}
 
-
-#
-# This function should do its best to remove the packages previously
-# installed by `install_dependencies` and leave the system clean.
-#
-remove_dependencies() {
-    local rpm_leaves
-    local zypper_global_opts
-    local zypper_command_opts
-    local libzypp_version
-
-    if [ -n "$INSTALLED_PACKAGES" ]; then
-        echo "Uninstalling the following packages: $INSTALLED_PACKAGES"
+    if [ -n "$missing_packages" ]; then
+        echo "Exiting... Following packages are missing: $missing_packages."
+        exit 101
     else
-        return
+        echo "All required packages installed: $packages"
     fi
 
-    case $OS in
-        ubuntu*|raspbian*)
-            execute sudo apt-get --assume-yes --purge remove $INSTALLED_PACKAGES
-            execute sudo apt-get --assume-yes --purge autoremove
-            ;;
-        rhel*)
-            execute sudo yum -y remove $INSTALLED_PACKAGES
-            # RHEL7's yum learned how to auto-remove installed dependencies.
-            if [ ${OS##rhel} -ge 7 ]; then
-                execute sudo yum -y autoremove
-            else
-                # This partially works in RHEL 4 to 6 for automatically
-                # removing packages installed as dependencies (aka "leaves").
-                rhel_yum_autoremove() {
-                    rpm_leaves=$(package-cleanup --leaves --quiet 2>/dev/null \
-                        | egrep -v ^'Excluding|Finished')
-                    if [ -z "$rpm_leaves" ]; then
-                        (exit 0)
-                    else
-                        execute sudo yum -y remove $rpm_leaves
-                        rhel_autoremove
-                    fi
-                }
-                rhel_yum_autoremove
-            fi
-            ;;
-        sles*)
-            zypper_global_opts="--non-interactive"
-            # zypper version 7.4 got support for automatically removing
-            # unneeded packages, but only when removing installed packages.
-            libzypp_version=$(rpm --query --queryformat '%{VERSION}' libzypp)
-            IFS=. read -a libzypp_version_array <<< "$libzypp_version"
-            if [ ${libzypp_version_array[0]} -gt 7 ]; then
-                zypper_command_opts="--clean-deps"
-            fi
-            execute sudo zypper $zypper_global_opts remove \
-                $zypper_command_opts $INSTALLED_PACKAGES
-            ;;
-    esac
 }
 
 
@@ -464,7 +402,7 @@ command_clean() {
 
 help_text_build="Create the Python binaries for current OS."
 command_build() {
-    install_dependencies
+    check_dependencies
 
     # Clean the build dir to avoid contamination from previous builds.
     command_clean

--- a/chevah_build
+++ b/chevah_build
@@ -383,9 +383,10 @@ check_dependencies() {
     fi
 
     if [ -n "$missing_packages" ]; then
-        echo "Exiting... Following packages are missing: $missing_packages."
+        echo "EXIT! Following packages are missing: $missing_packages."
         exit 101
-    else
+    fi
+    if [ -n "$packages" ]; then
         echo "All required packages installed: $packages"
     fi
 
@@ -469,8 +470,6 @@ command_build() {
                 execute cp lib/config/bin/$PYTHON_VERSION bin/python
             execute popd
     esac
-
-    remove_dependencies
 
     # Output the python-package version to a dedicated file in the archive.
     echo "${PYTHON_BUILD_VERSION}.${PYTHON_PACKAGE_VERSION}" \

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.67.4 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.14.620df8b0:solaris10@2.7.8.62700b56'
+BASE_REQUIREMENTS='chevah-brink==0.68.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.14.620df8b0:solaris10@2.7.8.c3d8a7d:aix71@2.7.13.25cf4cf:rhel7openssl101@2.7.10.8fa7d09'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -84,19 +84,13 @@ clean_build() {
     echo "Cleaning project temporary files..."
     rm -f DEFAULT_VALUES
     echo "Cleaning pyc files ..."
-    if [ $OS = "rhel4" ]; then
-        # RHEL 4 don't support + option in -exec
-        # We use -print0 and xargs to no fork for each file.
-        # find will fail if no file is found.
-        touch ./dummy_file_for_RHEL4.pyc
-        find ./ -name '*.pyc' -print0 | xargs -0 rm
-    else
-        # AIX's find complains if there are no matching files when using +.
-        [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
-        # Faster than '-exec rm {} \;' and supported in most OS'es,
-        # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
-        find ./ -name '*.pyc' -exec rm {} +
-    fi
+
+    # AIX's find complains if there are no matching files when using +.
+    [ $(uname) == AIX ] && touch ./dummy_file_for_AIX.pyc
+    # Faster than '-exec rm {} \;' and supported in most OS'es,
+    # details at http://www.in-ulm.de/~mascheck/various/find/#xargs
+    find ./ -name '*.pyc' -exec rm {} +
+
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
     # On the OSX build server tmp is in $TMPDIR
@@ -578,6 +572,16 @@ detect_os() {
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
                 check_os_version "Red Hat Enterprise Linux" 4 \
                     "$os_version_raw" os_version_chevah
+                # RHEL 7.4 and newer have OpenSSL 1.0.2, while 7.3 and older
+                # have version 1.0.1. Thus for the older RHEL 7 versions we use
+                # a separate OS signature, to make use of a dedicated Python
+                # package.
+                if [ "$os_version_chevah" -eq 7 ]; then
+                    if openssl version | grep -F -q "1.0.1"; then
+                        # We are on 1.0.1 which is pre RHEL 7.4
+                        os_version_chevah=7openssl101
+                    fi
+                fi
                 OS="rhel${os_version_chevah}"
             fi
         elif [ -f /etc/SuSE-release ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -570,7 +570,7 @@ detect_os() {
             if egrep -q 'Red\ Hat|CentOS|Scientific' /etc/redhat-release; then
                 os_version_raw=$(\
                     cat /etc/redhat-release | sed s/.*release// | cut -d' ' -f2)
-                check_os_version "Red Hat Enterprise Linux" 4 \
+                check_os_version "Red Hat Enterprise Linux" 5 \
                     "$os_version_raw" os_version_chevah
                 # RHEL 7.4 and newer have OpenSSL 1.0.2, while 7.3 and older
                 # have version 1.0.1. Thus for the older RHEL 7 versions we use

--- a/paver.sh
+++ b/paver.sh
@@ -396,7 +396,7 @@ copy_python() {
                 # Remove it and try to install it again.
                 echo "Updating Python from" \
                     $python_installed_version to $PYTHON_VERSION
-                rm -rf ${BUILD_FOLDER}
+                rm -rf ${BUILD_FOLDER}/*
                 rm -rf ${python_distributable}
                 copy_python
             fi
@@ -410,7 +410,7 @@ copy_python() {
                 echo "Updating Python from UNVERSIONED to $PYTHON_VERSION"
                 # We have a different python installed.
                 # Remove it and try to install it again.
-                rm -rf ${BUILD_FOLDER}
+                rm -rf ${BUILD_FOLDER}/*
                 rm -rf ${python_distributable}
                 copy_python
             else

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -134,17 +134,17 @@ def get_allowed_deps():
                 '/usr/lib/arm-linux-gnueabihf/libssl.so.1.0.0',
                 ]
         elif ('archlinux' in chevah_os):
-            # Full deps with paths for Arch Linux, as of Jan 2018.
+            # Full deps with paths for Arch Linux, as of March 2018.
             allowed_deps=[
                 '/usr/lib/libcrypto.so.1.1',
                 '/usr/lib/libcrypt.so.1',
                 '/usr/lib/libc.so.6',
                 '/usr/lib/libdl.so.2',
                 '/usr/lib/libm.so.6',
+                '/usr/lib/libncursesw.so.6',
                 '/usr/lib/libnsl.so.1',
                 '/usr/lib/libpthread.so.0',
                 '/usr/lib/libssl.so.1.1',
-                '/usr/lib/libtinfo.so.6',
                 '/usr/lib/libutil.so.1',
                 '/usr/lib/libz.so.1',
                 ]


### PR DESCRIPTION
Scope
=====

As discussed in #4092, remove code that automatically installs/uninstalls packages for building `python-package` and just make sure the dependencies of `chevah_build.sh` are documented. Also, relevant and helpful errors should be generated when needed binaries/libs are missing.

Changes
=======

Remove code that uninstalled packages.
Updated code that installed packages to only check for required packages.
Quit with a relevant error when one or more packages are missing, eg. https://chevah.com/buildbot/builders/python-package-sles-11/builds/6/steps/build/logs/stdio.

**Drive-by fixes**:
  * updated `paver.conf` and `paver.sh` from `server` repo
  * consequently, updated minimum supported RHEL version to major version 5
  * make it possible to use a symbolic link for `build/` sub-directory
  * updated deps for Arch Linux
  * updated Git on `solaris-11-sparc` and `win-xp` to support GitHub with TLS 1.2 only.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests.
`chevah.compat.tests.elevated.test_system_users:TestSystemUsersPAM.test_pamWithUsernameAndPassword_ok` fails on both OS X and MacOS.