### PR TITLE
[#4797] Updated packages for RHEL7 with OpenSSL 1.0.1 and HP-UX.

### DIFF
--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -42,13 +42,13 @@ def get_allowed_deps():
                 '/lib64/libutil.so.1',
                 '/lib64/libz.so.1',
                 ]
-            rhel_version = int(chevah_os[4:])
-            if rhel_version == 6:
+            rhel_version = chevah_os[4:]
+            if rhel_version.startswith("6"):
                 allowed_deps.extend([
                     '/usr/lib64/libcrypto.so.10',
                     '/usr/lib64/libssl.so.10',
                     ])
-            if rhel_version == 7:
+            if rhel_version.startswith("7"):
                 allowed_deps.extend([
                     '/lib64/libcrypto.so.10',
                     '/lib64/libpcre.so.1',
@@ -116,7 +116,6 @@ def get_allowed_deps():
                     '/lib/aarch64-linux-gnu/libz.so.1',
                     ]
         elif ('raspbian' in chevah_os):
-            raspbian_version = int(chevah_os[8:])
             # Common deps with full paths for Raspbian 7 and 8.
             allowed_deps=[
                 '/lib/arm-linux-gnueabihf/libcrypt.so.1',

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -103,7 +103,6 @@ chevahbs_configure() {
             LDFLAGS="${LDFLAGS} -lxnet"
             CONFIG_ARGS="${CONFIG_ARGS} \
                 --with-system-ffi \
-                --disable-ipv6 \
                 "
             ;;
         osx*|macos*)


### PR DESCRIPTION
Scope
=====

Update Python packages for OS'es with OpenSSL 1.0.1 for which we use older versions.

Changes
=======

Python 2.7.14 builds with no issues on RHEL 7.3 with OpenSSL 1.0.1. The lib deps tests needed a minor fix.

Couldn't build Python 2.7.14 on AIX 7.1 with OpenSSL 1.0.1e (there are several releases from IBM with this version, nothing worked for me). The issues are documented in the associated Trac ticket: https://trac.chevah.com/ticket/4797#comment:3.

This means on AIX we should keep using 2.7.13 until both clients stuck on the unsupported 1.0.1 version of OpenSSL upgrade to 1.0.2k.

**Drive-by change:**
  * stop disabling IPv6 support on HP-UX as it doesn't break the build any more with 2.7.14. 

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the changes.
Run the automated tests.
Check the updated packages with server, specifically the branch implementing IPv6 support, eg. https://chevah.com/buildbot/builders/server-hpux/builds/176