### PR TITLE
[#4833] Build libffi only when needed.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -350,6 +350,7 @@ case $OS in
     openbsd*)
         export CC="clang"
         export CXX="clang++"
+        export BUILD_LIBFFI="yes"
         # Fix from upstream, newer cryptography versions should work as-is.
         PIP_LIBRARIES="\
             setproctitle==${SETPROCTITLE_VERSION} \
@@ -361,8 +362,7 @@ case $OS in
     freebsd*)
         export CC="clang"
         export CXX="clang++"
-        # CFFI build doesn't find libffi.
-        export LDFLAGS="$LDFLAGS -L/usr/local/lib"
+        export BUILD_LIBFFI="yes"
         ;;
     linux*)
         # We don't compile libedit for generic Linux builds because it links

--- a/chevah_build
+++ b/chevah_build
@@ -110,25 +110,34 @@ PYTHON_VERSION=`cut -d' ' -f 2 DEFAULT_VALUES`
 OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 
-# List of OS packages required for building Python.
-COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
-DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
-RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel libffi-devel ncurses-devel"
-SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel libffi-devel ncurses-devel"
-if [ $OS = 'rhel5' ]; then
-    RHEL_PACKAGES="$RHEL_PACKAGES automake15"
-elif [ $OS = 'sles10' ]; then
-    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel libffi-devel ncurses-devel"
-elif [ $OS = 'sles11sm' ]; then
-    # SLES 11 with Security Module detected, we need the OpenSSL 1.0.x headers.
-    SLES_PACKAGES="$COMMON_PACKAGES libopenssl1-devel zlib-devel libffi-devel ncurses-devel"
-fi
+# List of OS packages required for building Python/pyOpenSSL/cryptography etc.
+COMMON_PKGS="gcc make m4 automake libtool texinfo"
+COMMON_SLES_PKGS="$COMMON_PKGS zlib-devel libffi-devel ncurses-devel"
+DEBIAN_PKGS="$COMMON_PKGS libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
+RHEL_PKGS="$COMMON_PKGS openssl-devel zlib-devel libffi-devel ncurses-devel"
+case "$OS" in
+    rhel5)
+        RHEL_PKGS="$RHEL_PKGS automake15"
+        ;;
+    sles10)
+        SLES_PKGS="$COMMON_SLES_PKGS openssl-devel"
+        ;;
+    sles11sm)
+        # SLES 11 with Security Module detected, OpenSSL 1.0.x headers needed.
+        SLES_PKGS="$COMMON_SLES_PKGS libopenssl1-devel"
+        ;;
+    sles12)
+        SLES_PKGS="$COMMON_SLES_PKGS libopenssl-devel"
+        ;;
+esac
 
-# List of OS packages requested to be installed by this script.
-INSTALLED_PACKAGES=''
-# For now, we don't install anything on OS X, Solaris, AIX, and
-# unsupported Linux distros. The build requires a C compiler, GNU make, m4,
-# the header files for OpenSSL and zlib, and (optionally) texinfo.
+# Lately we don't install anything automatically, we just check for the
+# presence of required packages on everything but macOS, Solaris, AIX, HP-UX
+# and unsupported Linux distros.
+# This build of Python / pyOpenSSL / cryptography / etc.  requires:
+# a C compiler, make, m4, libs and headers for OpenSSL, zlib, and libffi,
+# git (for patching Python's version), patch (for applying our own patches)
+# and optionally texinfo (link texinfo to `true` if missing on your platform).
 # To build libedit for the readline module, we need the headers of
 # a curses library, automake and libtool.
 # On platforms with a choice of C compilers, you may choose among the
@@ -145,8 +154,8 @@ export OS
 # Explicitly choose the C compiler in order to make it possible to switch
 # between native compilers and GCC on platforms such as AIX and Solaris.
 export CC='gcc'
-# CXX is not really needed, we export it to make sure g++ won't get picked up
-# when not using gcc, and thus silence the associated configure warning.
+# CXX is not really needed, we export it so that g++ won't get picked up when
+# not using gcc, and thus silence the associated configure warning on stderr.
 export CXX='g++'
 
 LOCAL_PYTHON_BINARY_DIST="$PYTHON_VERSION-$OS-$ARCH"
@@ -438,15 +447,15 @@ check_dependencies() {
     case $OS in
         # Debian-derived distros are similar in this regard.
         ubuntu*|raspbian*)
-            packages=$DEBIAN_PACKAGES
+            packages=$DEBIAN_PKGS
             check_command='dpkg --status'
         ;;
         rhel*)
-            packages=$RHEL_PACKAGES
+            packages=$RHEL_PKGS
             check_command='rpm --query'
         ;;
         sles*)
-            packages=$SLES_PACKAGES
+            packages=$SLES_PKGS
             check_command='rpm --query'
         ;;
         macos*)

--- a/chevah_build
+++ b/chevah_build
@@ -112,16 +112,16 @@ ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 
 # List of OS packages required for building Python.
 COMMON_PACKAGES="gcc make m4 automake libtool texinfo"
-DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libncurses5-dev"
-RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
-SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel ncurses-devel"
+DEBIAN_PACKAGES="$COMMON_PACKAGES libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
+RHEL_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel libffi-devel ncurses-devel"
+SLES_PACKAGES="$COMMON_PACKAGES libopenssl-devel zlib-devel libffi-devel ncurses-devel"
 if [ $OS = 'rhel5' ]; then
     RHEL_PACKAGES="$RHEL_PACKAGES automake15"
 elif [ $OS = 'sles10' ]; then
-    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel ncurses-devel"
+    SLES_PACKAGES="$COMMON_PACKAGES openssl-devel zlib-devel libffi-devel ncurses-devel"
 elif [ $OS = 'sles11sm' ]; then
     # SLES 11 with Security Module detected, we need the OpenSSL 1.0.x headers.
-    SLES_PACKAGES="$COMMON_PACKAGES libopenssl1-devel zlib-devel ncurses-devel"
+    SLES_PACKAGES="$COMMON_PACKAGES libopenssl1-devel zlib-devel libffi-devel ncurses-devel"
 fi
 
 # List of OS packages requested to be installed by this script.

--- a/chevah_build
+++ b/chevah_build
@@ -361,6 +361,8 @@ case $OS in
     freebsd*)
         export CC="clang"
         export CXX="clang++"
+        # CFFI build doesn't find libffi.
+        export LDFLAGS="$LDFLAGS -L/usr/local/lib"
         ;;
     linux*)
         # We don't compile libedit for generic Linux builds because it links

--- a/chevah_build
+++ b/chevah_build
@@ -47,7 +47,7 @@ export PYTHON_BUILD_VERSION PYTHON_PACKAGE_VERSION REDISTRIBUTABLE_VERSION
 export BUILD_ZLIB="no"
 export BUILD_LIBEDIT="yes"
 export BUILD_GMP="yes"
-export BUILD_LIBFFI="yes"
+export BUILD_LIBFFI="no"
 export BUILD_CFFI="yes"
 EXTRA_LIBRARIES="\
     python-modules/cffi-${CFFI_VERSION} \
@@ -188,6 +188,7 @@ case $OS in
                 export CFLAGS="$CFLAGS -qmaxmem=-1 -q64"
             fi
         fi
+        export BUILD_LIBFFI="yes"
         # libedit requires __STDC_ISO_10646__.
         export BUILD_LIBEDIT="no"
         ;;
@@ -305,6 +306,7 @@ case $OS in
         export CXX="/opt/aCC/bin/aCC"
         # Native make is needed for parallel builds.
         export MAKE="make -P"
+        export BUILD_LIBFFI="yes"
         export BUILD_ZLIB="yes"
         # libedit requires __STDC_ISO_10646__.
         export BUILD_LIBEDIT="no"
@@ -384,8 +386,6 @@ case $OS in
         # For Windows we don't build everything from source yet.
         export BUILD_LIBEDIT="no"
         export BUILD_GMP="no"
-        # We don't build libffi, as cffi it is available as a wheel in pypi.
-        export BUILD_LIBFFI="no"
         ;;
 esac
 

--- a/chevah_build
+++ b/chevah_build
@@ -344,7 +344,7 @@ case $OS in
         export CPPFLAGS="$CPPFLAGS -I/usr/local/opt/openssl/include"
         # setup.py skips building readline by default, as it sets this to
         # "10.4", and then tries to avoid the broken readline in OS X 10.4.
-        export MACOSX_DEPLOYMENT_TARGET=10.12
+        export MACOSX_DEPLOYMENT_TARGET=10.11
         ;;
 
     openbsd*)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -144,6 +144,7 @@ def get_allowed_deps():
                 '/lib/arm-linux-gnueabihf/libutil.so.1',
                 '/lib/arm-linux-gnueabihf/libz.so.1',
                 '/usr/lib/arm-linux-gnueabihf/libcrypto.so.1.0.0',
+                '/usr/lib/arm-linux-gnueabihf/libffi.so.5',
                 '/usr/lib/arm-linux-gnueabihf/libssl.so.1.0.0',
                 ]
         elif ('archlinux' in chevah_os):
@@ -407,7 +408,6 @@ def get_allowed_deps():
             '/lib/libthr.so.3',
             '/lib/libutil.so.9',
             '/lib/libz.so.6',
-            '/usr/local/lib/libffi.so.6',
             ]
         # On FreeBSD this can be: '10.3-RELEASE-p20', '11.0-RELEASE', etc.
         freebsd_version = platform.release().split('.')[0]
@@ -435,7 +435,6 @@ def get_allowed_deps():
             '/usr/lib/libutil.so',
             '/usr/lib/libz.so',
             '/usr/libexec/ld.so',
-            '/usr/local/lib/libffi.so.1.2',
             ]
     elif platform_system == 'netbsd':
         # This is the list of specific deps for NetBSD 7.x, with paths.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -46,11 +46,13 @@ def get_allowed_deps():
             if rhel_version.startswith("6"):
                 allowed_deps.extend([
                     '/usr/lib64/libcrypto.so.10',
+                    '/usr/lib64/libffi.so.5',
                     '/usr/lib64/libssl.so.10',
                     ])
             if rhel_version.startswith("7"):
                 allowed_deps.extend([
                     '/lib64/libcrypto.so.10',
+                    '/lib64/libffi.so.6',
                     '/lib64/libpcre.so.1',
                     '/lib64/libssl.so.10',
                     ])
@@ -67,6 +69,7 @@ def get_allowed_deps():
                 '/lib64/libpthread.so.0',
                 '/lib64/libutil.so.1',
                 '/lib64/libz.so.1',
+                '/usr/lib64/libffi.so.6',
                 ]
             if sles_version == "11":
                 allowed_deps.extend([
@@ -97,6 +100,7 @@ def get_allowed_deps():
                 '/lib/x86_64-linux-gnu/libtinfo.so.5',
                 '/lib/x86_64-linux-gnu/libutil.so.1',
                 '/lib/x86_64-linux-gnu/libz.so.1',
+                '/usr/lib/x86_64-linux-gnu/libffi.so.6',
                 ]
             if ubuntu_version in [ "1404", "1604" ]:
                 allowed_deps.extend([
@@ -123,6 +127,7 @@ def get_allowed_deps():
                     '/lib/aarch64-linux-gnu/libtinfo.so.5',
                     '/lib/aarch64-linux-gnu/libutil.so.1',
                     '/lib/aarch64-linux-gnu/libz.so.1',
+                    '/usr/lib/aarch64-linux-gnu/libffi.so.6',
                     ]
         elif ('raspbian' in chevah_os):
             # Common deps with full paths for Raspbian 7 and 8.
@@ -148,6 +153,7 @@ def get_allowed_deps():
                 '/usr/lib/libcrypt.so.1',
                 '/usr/lib/libc.so.6',
                 '/usr/lib/libdl.so.2',
+                '/usr/lib/libffi.so.6',
                 '/usr/lib/libm.so.6',
                 '/usr/lib/libncursesw.so.6',
                 '/usr/lib/libnsl.so.1',
@@ -164,6 +170,7 @@ def get_allowed_deps():
                 '/lib/libcrypto.so.41',
                 '/lib/libssl.so.43',
                 '/lib/libz.so.1',
+                '/usr/lib/libffi.so.6',
                 '/usr/lib/libncursesw.so.6',
                 ]
         else:
@@ -173,17 +180,15 @@ def get_allowed_deps():
                 'libcrypt.so.1',
                 'libcrypto.so.1.0.0',
                 'libdl.so.2',
+                'libffi.so.5',
                 'libm.so.6',
                 'libnsl.so.1',
                 'libpthread.so.0',
                 'libssl.so.1.0.0',
                 'libutil.so.1',
                 'libz.so.1',
+                'libgcc_s.so.1',
                 ]
-            if 'x64' in chevah_arch:
-                allowed_deps.extend([
-                    'libgcc_s.so.1',
-                ])
     elif platform_system == 'aix':
         # List of deps with full paths for AIX 5.3 with OpenSSL 1.0.2k.
         # These deps are common to AIX 6.1 and 7.1 as well.
@@ -277,11 +282,13 @@ def get_allowed_deps():
                     ])
                 if 'sparc' in chevah_arch:
                     allowed_deps.extend([
+                        '/usr/lib/sparcv9/libffi.so.5',
                         '/usr/lib/sparcv9/libc.so.1',
                         ])
                 else:
                     allowed_deps.extend([
                         '/lib/64/libelf.so.1',
+                        '/usr/lib/64/libffi.so.5',
                         '/usr/lib/amd64/libc.so.1',
                         ])
         else:
@@ -344,6 +351,7 @@ def get_allowed_deps():
                     '/lib/libssl.so.1.0.0',
                     '/lib/libz.so.1',
                     '/usr/lib/libcrypt.so.1',
+                    '/usr/lib/libffi.so.5',
                     '/usr/lib/libncurses.so.5',
                     '/usr/lib/libsqlite3.so.0',
                     ])
@@ -370,6 +378,7 @@ def get_allowed_deps():
             '/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices',
             '/System/Library/Frameworks/Security.framework/Versions/A/Security',
             '/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration',
+            '/usr/lib/libffi.dylib',
             '/usr/lib/libSystem.B.dylib',
             '/usr/lib/libz.1.dylib',
             ]
@@ -398,6 +407,7 @@ def get_allowed_deps():
             '/lib/libthr.so.3',
             '/lib/libutil.so.9',
             '/lib/libz.so.6',
+            '/usr/local/lib/libffi.so.6',
             ]
         # On FreeBSD this can be: '10.3-RELEASE-p20', '11.0-RELEASE', etc.
         freebsd_version = platform.release().split('.')[0]
@@ -425,6 +435,7 @@ def get_allowed_deps():
             '/usr/lib/libutil.so',
             '/usr/lib/libz.so',
             '/usr/libexec/ld.so',
+            '/usr/local/lib/libffi.so.1.2',
             ]
     elif platform_system == 'netbsd':
         # This is the list of specific deps for NetBSD 7.x, with paths.


### PR DESCRIPTION
Scope
=====

Our bundled `libffi` is used twice:

  1. by Python if using `--with-system-ffi` (on AIX and HP-UX)
  2. by CFFI (on all platforms where we use pip/cffi/cryptography).

Stop building `libffi` unnecessarily on OS'es which bundle and support it. Linking to OS-provided `libffi` means one less liability from a security point of view.

Changes
=======

Build CFFI against OS libs where this is possible (everywhere but AIX and HP-UX).

But also on the BSDs, where `libffi` is not included in the base system and has to be installed as a package. I'm ambivalent about this one though, as you can see from the history of changes.

Systems not building CFFI are not affected (currently Windows and Solaris 10).

Systems not tested, but for which I deduced required deps: Solaris 11 SPARC 64bit (as we force 32bit builds) and Raspbian 7.

**Drive-by fixes**:
  * lower `MACOSX_DEPLOYMENT_TARGET` to 10.11 in preparation for dropping support for OS X 10.8 - 10.10
  * cosmetic changes for how we document and check for needed packages on some Linux distros.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests.