### PR TITLE
[#4205] HP-UX build fixes.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -310,16 +310,14 @@ case $OS in
         ;;
     hpux*)
         # GCC and the bundled /usr/ccs/bin/cc will fail with pycrypto.
-        # We prefer "aCC -Ae" over "cc" because it does parallel builds better.
-        export CC="/opt/aCC/bin/aCC -Ae"
-        export CXX="/opt/aCC/bin/aCC"
+        # "aCC -Ae" does parallel builds better, but beware of race conditions.
+        # Don't use CFLAGS with native ld, it chokes on some parameters.
+        # An alternative is LDSHARED="/opt/aCC/bin/aCC -b" with CC="aCC -Ae".
         # As little warnings as possible, HP's compilers generate lots.
         # Force 32bit binaries (the OS default) and Position-Independent Code.
-        export CFLAGS="-w +DD32 +Z"
-        # Included ld is limited, chokes on compiler flags such as -w or +DD64.
-        export LDSHARED="/opt/aCC/bin/aCC -b"
-        export LDFLAGS="+DD32"
-        # Native make is needed for parallel builds.
+        export CC="/opt/aCC/bin/cc -w +DD32 +z"
+        export CXX="/opt/aCC/bin/aCC"
+        # Native make needed for parallel builds, use gmake where this breaks.
         export MAKE="make -P"
         export BUILD_LIBFFI="yes"
         export BUILD_ZLIB="yes"

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.68.0 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.14.620df8b0:solaris10@2.7.8.c3d8a7d:aix71@2.7.13.25cf4cf:rhel7openssl101@2.7.14.2408956a:hpux1131@2.7.14.2408956a:freebsd10@2.7.14.54617290:openbsd63@2.7.14.a233222f:ubuntu1804@2.7.14.54617290'
+BASE_REQUIREMENTS='chevah-brink==0.69.1 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.15.544b30b0:solaris10@2.7.8.544b30b0'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/src/gmp/chevahbs
+++ b/src/gmp/chevahbs
@@ -23,7 +23,11 @@ chevahbs_configure() {
     case $OS in
         raspbian*)
             CONF_OPTS="$CONF_OPTS --build=armcortexa8neon-unknown-linux-gnueabihf --with-pic"
-        ;;
+            ;;
+        hpux*)
+            # Parallel builds frequently fail for GMP, so we use gmake here.
+            MAKE="gmake"
+            ;;
     esac
     execute ./configure --prefix="" $CONF_OPTS
 }

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -16,8 +16,6 @@ chevahbs_configure() {
             CXX="g++"
             MAKE="gmake"
             unset CFLAGS
-            unset LDFLAGS
-            unset LDSHARED
             ;;
     esac
     # We want only static build so that we don't have to mess with LIBPATH.

--- a/src/python/chevahbs
+++ b/src/python/chevahbs
@@ -116,6 +116,8 @@ chevahbs_configure() {
             fi
             ;;
         hpux*)
+            # Parallel builds on Python sometimes fail, so we use gmake here.
+            MAKE="gmake"
             LDFLAGS="${LDFLAGS} -lxnet"
             CONFIG_ARGS="${CONFIG_ARGS} \
                 --with-system-ffi \


### PR DESCRIPTION
Scope
=====

HP-UX python-package builds sometimes fail on Mosna.

Initially, this seems to be related to Mosna specifically, but further testing focused on this specific issue revealed the root cause for this to be parallel building, especially for GMP, but sometimes for Python as well.

Changes
=======

Use `gmake` for GMP and Python on HP-UX. This means no parallel builds for these two components on HP-UX.

Switch back to using the regular C compiler on HP-UX, instead of the C++ compiler in _C mode_. This was only necessary for building GMP with more than 2 threads.

**Drive-by change**:
  * updated `paver.conf` with latest stuff.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the tests. You'll have to do 10 in a row to make sure these failures are gone.