### PR TITLE
[#4773] Package verification for all Linux distros, check essential commands everywhere else.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -114,7 +114,7 @@ OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 
 # List of OS packages required for building Python/pyOpenSSL/cryptography etc.
-COMMON_PKGS="gcc make m4 automake libtool texinfo patch"
+COMMON_PKGS="gcc make m4 automake libtool texinfo git patch"
 COMMON_SLES_PKGS="$COMMON_PKGS zlib-devel libffi-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
 RHEL_PKGS="$COMMON_PKGS openssl-devel zlib-devel libffi-devel ncurses-devel"

--- a/chevah_build
+++ b/chevah_build
@@ -137,11 +137,11 @@ case "$OS" in
 esac
 
 # Lately we don't install anything automatically, we just check for the
-# presence of required packages on everything but macOS, Solaris, AIX, HP-UX
-# and unsupported Linux distros.
+# presence of required packages on everything but AIX, HP-UX, macOS, OS X,
+# Solaris, Windows and generic Linux builds.
 # This build of Python / pyOpenSSL / cryptography / etc.  requires:
-# a C compiler, make, m4, libs and headers for OpenSSL, zlib, and libffi,
-# git (for patching Python's version), patch (for applying our own patches)
+# a C compiler, make, m4, libs and headers for OpenSSL / zlib / libffi,
+# git (for patching Python's version), patch (for applying our own patches),
 # and optionally texinfo (link texinfo to `true` if missing on your platform).
 # To build libedit for the readline module, we need the headers of
 # a curses library, automake and libtool.
@@ -151,7 +151,7 @@ esac
 # In Solaris and AIX we use $ARCH to choose if we build a 32bit or 64bit
 # package. This way we are able to force a 32bit build on a 64bit machine,
 # for example by exporting ARCH in paver.sh as "x86" instead of "x64" or
-# "ppc" instead of "ppc64".
+# "ppc" instead of "ppc64". Except on HP-UX, where we always do 32bit builds.
 # We also use $ARCH when building the statically compiled libffi and GMP.
 # $OS is used when patching/configuring/building/testing.
 export ARCH

--- a/chevah_build
+++ b/chevah_build
@@ -483,6 +483,8 @@ check_dependencies() {
                 echo "Unsupported OpenSSL version: $homebrew_openssl_version"
                 exit 102
             fi
+            packages="$CC make m4 libtool git patch"
+            check_command="command -v"
             ;;
         # On remaining OS'es we just check for some of the needed commands.
         windows)
@@ -535,6 +537,7 @@ command_clean() {
 help_text_build="Create the Python binaries for current OS."
 command_build() {
     check_dependencies
+    exit 0
 
     # Clean the build dir to avoid contamination from previous builds.
     command_clean

--- a/chevah_build
+++ b/chevah_build
@@ -484,6 +484,21 @@ check_dependencies() {
                 exit 102
             fi
         ;;
+        # On remaining OS'es we just check for some of the needed commands.
+        windows)
+            # The windows build is special.
+            packages="make git patch"
+            check_command="command -v"
+        ;;
+        hpux*)
+            # Included CFLAGS get in the way on HP-UX.
+            packages="/opt/aCC/bin/cc make m4 git patch"
+            check_command="command -v"
+        ;;
+        *)
+            packages="$CC make m4 git patch"
+            check_command="command -v"
+        ;;
     esac
 
     if [ -n "$packages" ]; then

--- a/chevah_build
+++ b/chevah_build
@@ -475,14 +475,14 @@ check_dependencies() {
             check_command='pacman -Qi'
             ;;
         macos*)
-            # On macOS we need OpenSSL installed via homebrew, but we don't
-            # do it automatically, here we only check that the expected
-            # OpenSSL version is installed, as hardcoded below.
+            # On macOS we need OpenSSL installed via Homebrew, and here we
+            # check that the expected version is installed, as hardcoded below.
             homebrew_openssl_version=`brew list --versions openssl`
             if [[ $homebrew_openssl_version != "openssl 1.0.2"* ]]; then
                 echo "Unsupported OpenSSL version: $homebrew_openssl_version"
                 exit 102
             fi
+            # But we also check for the required commands, as for below OS'es.
             packages="$CC make m4 libtool git patch"
             check_command="command -v"
             ;;
@@ -504,9 +504,9 @@ check_dependencies() {
     esac
 
     if [ -n "$packages" ]; then
-        echo "Checking for packages to be installed..."
+        echo "Checking for required packages or commands..."
         for package in $packages ; do
-            echo "Checking if $package is installed..."
+            echo "Checking if $package is available..."
             $check_command $package
             if [ $? -ne 0 ]; then
                 echo "Missing required dependency: $package"
@@ -516,11 +516,11 @@ check_dependencies() {
     fi
 
     if [ -n "$missing_packages" ]; then
-        echo "EXIT! Following packages are missing: $missing_packages."
+        echo "Sorry, following dependencies were not found: $missing_packages."
         exit 101
     fi
     if [ -n "$packages" ]; then
-        echo "All required packages installed: $packages"
+        echo "All required dependencies are present: $packages"
     fi
 
 }
@@ -537,7 +537,6 @@ command_clean() {
 help_text_build="Create the Python binaries for current OS."
 command_build() {
     check_dependencies
-    exit 0
 
     # Clean the build dir to avoid contamination from previous builds.
     command_clean

--- a/chevah_build
+++ b/chevah_build
@@ -118,6 +118,7 @@ COMMON_PKGS="gcc make m4 automake libtool texinfo"
 COMMON_SLES_PKGS="$COMMON_PKGS zlib-devel libffi-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
 RHEL_PKGS="$COMMON_PKGS openssl-devel zlib-devel libffi-devel ncurses-devel"
+ALPINE_PKGS="$COMMON_PKGS libc-dev libressl-dev zlib-dev libffi-dev ncurses-dev"
 case "$OS" in
     rhel5)
         RHEL_PKGS="$RHEL_PKGS automake15"
@@ -462,6 +463,10 @@ check_dependencies() {
         sles*)
             packages=$SLES_PKGS
             check_command='rpm --query'
+        ;;
+        alpine*)
+            packages=$ALPINE_PKGS
+            check_command='apk info'
         ;;
         macos*)
             # On macOS we need OpenSSL installed via homebrew, but we don't

--- a/chevah_build
+++ b/chevah_build
@@ -114,7 +114,7 @@ OS=`cut -d' ' -f 3 DEFAULT_VALUES`
 ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 
 # List of OS packages required for building Python/pyOpenSSL/cryptography etc.
-COMMON_PKGS="gcc make m4 automake libtool texinfo"
+COMMON_PKGS="gcc make m4 automake libtool texinfo patch"
 COMMON_SLES_PKGS="$COMMON_PKGS zlib-devel libffi-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
 RHEL_PKGS="$COMMON_PKGS openssl-devel zlib-devel libffi-devel ncurses-devel"

--- a/chevah_build
+++ b/chevah_build
@@ -448,7 +448,8 @@ fi
 #
 check_dependencies() {
 
-    missing_packages=""
+    packages=''
+    missing_packages=''
 
     case $OS in
         # Debian-derived distros are similar in this regard.
@@ -477,10 +478,6 @@ check_dependencies() {
                 echo "Unsupported OpenSSL version: $homebrew_openssl_version"
                 exit 102
             fi
-            packages=''
-        ;;
-        *)
-            packages=''
         ;;
     esac
 

--- a/chevah_build
+++ b/chevah_build
@@ -457,23 +457,23 @@ check_dependencies() {
         ubuntu*|raspbian*)
             packages=$DEBIAN_PKGS
             check_command='dpkg --status'
-        ;;
+            ;;
         rhel*)
             packages=$RHEL_PKGS
             check_command='rpm --query'
-        ;;
+            ;;
         sles*)
             packages=$SLES_PKGS
             check_command='rpm --query'
-        ;;
+            ;;
         alpine*)
             packages=$ALPINE_PKGS
             check_command='apk info'
-        ;;
+            ;;
         archlinux)
             packages=$ARCH_PKGS
             check_command='pacman -Qi'
-        ;;
+            ;;
         macos*)
             # On macOS we need OpenSSL installed via homebrew, but we don't
             # do it automatically, here we only check that the expected
@@ -483,22 +483,22 @@ check_dependencies() {
                 echo "Unsupported OpenSSL version: $homebrew_openssl_version"
                 exit 102
             fi
-        ;;
+            ;;
         # On remaining OS'es we just check for some of the needed commands.
         windows)
             # The windows build is special.
             packages="make git patch"
             check_command="command -v"
-        ;;
+            ;;
         hpux*)
             # Included CFLAGS get in the way on HP-UX.
             packages="/opt/aCC/bin/cc make m4 git patch"
             check_command="command -v"
-        ;;
+            ;;
         *)
             packages="$CC make m4 git patch"
             check_command="command -v"
-        ;;
+            ;;
     esac
 
     if [ -n "$packages" ]; then

--- a/chevah_build
+++ b/chevah_build
@@ -131,7 +131,7 @@ case "$OS" in
         # SLES 11 with Security Module detected, OpenSSL 1.0.x headers needed.
         SLES_PKGS="$COMMON_SLES_PKGS libopenssl1-devel"
         ;;
-    sles12)
+    sles11|sles12)
         SLES_PKGS="$COMMON_SLES_PKGS libopenssl-devel"
         ;;
 esac

--- a/chevah_build
+++ b/chevah_build
@@ -119,6 +119,7 @@ COMMON_SLES_PKGS="$COMMON_PKGS zlib-devel libffi-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
 RHEL_PKGS="$COMMON_PKGS openssl-devel zlib-devel libffi-devel ncurses-devel"
 ALPINE_PKGS="$COMMON_PKGS libc-dev libressl-dev zlib-dev libffi-dev ncurses-dev"
+ARCH_PKGS="$COMMON_PKGS libffi ncurses"
 case "$OS" in
     rhel5)
         RHEL_PKGS="$RHEL_PKGS automake15"
@@ -468,6 +469,10 @@ check_dependencies() {
         alpine*)
             packages=$ALPINE_PKGS
             check_command='apk info'
+        ;;
+        archlinux)
+            packages=$ARCH_PKGS
+            check_command='pacman -Qi'
         ;;
         macos*)
             # On macOS we need OpenSSL installed via homebrew, but we don't


### PR DESCRIPTION
Scope
=====

Following the work in Trac ticket #4712, we don't install/uninstall packages anymore when building Python, but we check for required packages on some of the systems.

We could add Alpine to that list of systems.


Changes
=======

Check required packages in Alpine with `apk` (and in Arch Linux with `pacman` while at it).

Check that essential commands are present on OS'es where we don't check for installed packages: Windows, the Unices, OSX/macOS, the BSDs and generic Linux.

**Drive-by changes**:
  * also check for `git` and `patch` everywhere as they are actually required
  * fixed a bug that prevented package verification on SLES 11 in last revisions
  * various related minor fixes: comments, outputs, code syntax.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.
Run the automated tests for all OS'es, eg. https://chevah.com/buildbot/builders/python-package-group-all/builds/16.
Add a common fake required package and/or command and check that the build is not started.