### PR TITLE
[#5023] Debian-specific packages.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -367,11 +367,6 @@ case $OS in
         export CXX="clang++"
         export BUILD_LIBFFI="yes"
         ;;
-    linux*)
-        # We don't compile libedit for generic Linux builds because it links
-        # to local ncurses libs and the result is not very portable.
-        export BUILD_LIBEDIT="no"
-        ;;
     sles11sm)
         # Use PyCryptodome's wheel, as there are issues not solved upstream yet.
         PIP_LIBRARIES="\
@@ -457,7 +452,7 @@ check_dependencies() {
 
     case $OS in
         # Debian-derived distros are similar in this regard.
-        ubuntu*|raspbian*)
+        ubuntu*|debian*|raspbian*)
             packages=$DEBIAN_PKGS
             check_command='dpkg --status'
             ;;

--- a/paver.sh
+++ b/paver.sh
@@ -640,6 +640,10 @@ detect_os() {
                     # Arch Linux is a rolling distro, no version info available.
                     OS="archlinux"
                     ;;
+                *)
+                    echo 'Unsupported Linux distribution:' $ID
+                    exit 15
+                    ;;
             esac
         fi
     elif [ "${OS}" = "darwin" ]; then

--- a/paver.sh
+++ b/paver.sh
@@ -618,6 +618,12 @@ detect_os() {
                         echo "Unsupported Ubuntu, using generic Linux binaries!"
                     fi
                     ;;
+                "debian")
+                    os_version_raw="$VERSION_ID"
+                    check_os_version "$distro_fancy_name" 7 \
+                        "$os_version_raw" os_version_chevah
+                    OS="debian${os_version_chevah}"
+                    ;;
                 "raspbian")
                     os_version_raw="$VERSION_ID"
                     check_os_version "$distro_fancy_name" 7 \

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -174,8 +174,8 @@ def get_allowed_deps():
                 '/usr/lib/libffi.so.6',
                 '/usr/lib/libncursesw.so.6',
                 ]
-        else:
-            # Deps for generic Linux (currently Debian 7), sans paths.
+        elif ('debian' in chevah_os):
+            # Deps for Debian version 7, sans paths, to match all arches.
             allowed_deps=[
                 'libc.so.6',
                 'libcrypt.so.1',
@@ -183,8 +183,10 @@ def get_allowed_deps():
                 'libdl.so.2',
                 'libffi.so.5',
                 'libm.so.6',
+                'libncurses.so.5',
                 'libnsl.so.1',
                 'libpthread.so.0',
+                'libtinfo.so.5',
                 'libssl.so.1.0.0',
                 'libutil.so.1',
                 'libz.so.1',


### PR DESCRIPTION
Scope
=====

As discussed in Trac ticket #4986 and on private IRC, we should have specific Python packages for Debian (both x86 and x64).

The updated `paver.sh` should be integrated into server.


Changes
=======

Treat Debian as supported Linux distro.


How to try and test the changes
===============================

reviewers: **WIP**