### PR TITLE
[#5084] Debian packages with PyCrypto.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -378,11 +378,6 @@ case $OS in
         export CXX="clang++"
         export BUILD_LIBFFI="yes"
         ;;
-    linux*)
-        # We don't compile libedit for generic Linux builds because it links
-        # to local ncurses libs and the result is not very portable.
-        export BUILD_LIBEDIT="no"
-        ;;
     rhel5|sles11)
         # OS'es with OpenSSL 0.9.8 libs, older cryptography would be needed,
         # but upstream provides a Linux wheel that works, at least on SLES 11.
@@ -460,7 +455,7 @@ check_dependencies() {
 
     case $OS in
         # Debian-derived distros are similar in this regard.
-        ubuntu*|raspbian*)
+        ubuntu*|debian*|raspbian*)
             packages=$DEBIAN_PKGS
             check_command='dpkg --status'
             ;;

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1'
+PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1:debian7@2.7.15.db42da13'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.69.1 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.544b30b0:solaris10@2.7.8.544b30b0'
+BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -227,12 +227,11 @@ pip_install() {
     # See https://github.com/pypa/pip/issues/3564
     rm -rf ${BUILD_FOLDER}/pip-build
     ${PYTHON_BIN} -m \
-        pip.__init__ install $1 \
+        pip install $1 \
             --trusted-host pypi.chevah.com \
             --index-url=$PIP_INDEX/simple \
             --build=${BUILD_FOLDER}/pip-build \
-            --cache-dir=${CACHE_FOLDER} \
-            --use-wheel
+            --cache-dir=${CACHE_FOLDER}
 
     exit_code=$?
     set -e
@@ -604,7 +603,7 @@ detect_os() {
             linux_distro="$ID"
             distro_fancy_name="$NAME"
             case "$linux_distro" in
-                "ubuntu")
+                "ubuntu"|"ubuntu-core")
                     os_version_raw="$VERSION_ID"
                     check_os_version "$distro_fancy_name" 14.04 \
                         "$os_version_raw" os_version_chevah
@@ -615,8 +614,15 @@ detect_os() {
                         $(( ${os_version_chevah%%04} % 2 )) -eq 0 ]; then
                         OS="ubuntu${os_version_chevah}"
                     else
-                        echo "Unsupported Ubuntu, using generic Linux binaries!"
+                        echo "Unsupported Ubuntu, please try a LTS version!"
+                        exit 16
                     fi
+                    ;;
+                "debian")
+                    os_version_raw="$VERSION_ID"
+                    check_os_version "$distro_fancy_name" 7 \
+                        "$os_version_raw" os_version_chevah
+                    OS="debian${os_version_chevah}"
                     ;;
                 "raspbian")
                     os_version_raw="$VERSION_ID"
@@ -633,6 +639,10 @@ detect_os() {
                 "arch")
                     # Arch Linux is a rolling distro, no version info available.
                     OS="archlinux"
+                    ;;
+                *)
+                    echo "Unsupported Linux distribution type: $linux_distro."
+                    exit 15
                     ;;
             esac
         fi

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -129,6 +129,40 @@ def get_allowed_deps():
                     '/lib/aarch64-linux-gnu/libz.so.1',
                     '/usr/lib/aarch64-linux-gnu/libffi.so.6',
                     ]
+        elif ('debian' in chevah_os):
+            # Full deps for Debian 7.x amd64.
+            allowed_deps=[
+                '/lib/x86_64-linux-gnu/libcrypt.so.1',
+                '/lib/x86_64-linux-gnu/libc.so.6',
+                '/lib/x86_64-linux-gnu/libdl.so.2',
+                '/lib/x86_64-linux-gnu/libgcc_s.so.1',
+                '/lib/x86_64-linux-gnu/libm.so.6',
+                '/lib/x86_64-linux-gnu/libncurses.so.5',
+                '/lib/x86_64-linux-gnu/libpthread.so.0',
+                '/lib/x86_64-linux-gnu/libtinfo.so.5',
+                '/lib/x86_64-linux-gnu/libutil.so.1',
+                '/lib/x86_64-linux-gnu/libz.so.1',
+                '/usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0',
+                '/usr/lib/x86_64-linux-gnu/libffi.so.5',
+                '/usr/lib/x86_64-linux-gnu/libssl.so.1.0.0',
+                ]
+            if 'x86' in chevah_arch:
+                # Full deps for Debian 7.x i386.
+                allowed_deps=[
+                    '/lib/i386-linux-gnu/i686/cmov/libc.so.6',
+                    '/lib/i386-linux-gnu/i686/cmov/libcrypt.so.1',
+                    '/lib/i386-linux-gnu/i686/cmov/libdl.so.2',
+                    '/lib/i386-linux-gnu/i686/cmov/libm.so.6',
+                    '/lib/i386-linux-gnu/i686/cmov/libpthread.so.0',
+                    '/lib/i386-linux-gnu/i686/cmov/libutil.so.1',
+                    '/lib/i386-linux-gnu/libgcc_s.so.1',
+                    '/lib/i386-linux-gnu/libncurses.so.5',
+                    '/lib/i386-linux-gnu/libtinfo.so.5',
+                    '/lib/i386-linux-gnu/libz.so.1',
+                    '/usr/lib/i386-linux-gnu/i686/cmov/libcrypto.so.1.0.0',
+                    '/usr/lib/i386-linux-gnu/i686/cmov/libssl.so.1.0.0',
+                    '/usr/lib/i386-linux-gnu/libffi.so.5',
+                    ]
         elif ('raspbian' in chevah_os):
             # Common deps with full paths for Raspbian 7 and 8.
             allowed_deps=[
@@ -147,6 +181,17 @@ def get_allowed_deps():
                 '/usr/lib/arm-linux-gnueabihf/libffi.so.5',
                 '/usr/lib/arm-linux-gnueabihf/libssl.so.1.0.0',
                 ]
+        elif ('alpine' in chevah_os):
+            # Full deps with paths, but no minor versions, for Alpine 3.6.
+            allowed_deps=[
+                '/lib/ld-musl-x86_64.so.1',
+                '/lib/libc.musl-x86_64.so.1',
+                '/lib/libcrypto.so.41',
+                '/lib/libssl.so.43',
+                '/lib/libz.so.1',
+                '/usr/lib/libffi.so.6',
+                '/usr/lib/libncursesw.so.6',
+                ]
         elif ('archlinux' in chevah_os):
             # Full deps with paths for Arch Linux, as of March 2018.
             allowed_deps=[
@@ -162,33 +207,6 @@ def get_allowed_deps():
                 '/usr/lib/libssl.so.1.1',
                 '/usr/lib/libutil.so.1',
                 '/usr/lib/libz.so.1',
-                ]
-        elif ('alpine' in chevah_os):
-            # Full deps with paths, but no minor versions, for Alpine 3.6.
-            allowed_deps=[
-                '/lib/ld-musl-x86_64.so.1',
-                '/lib/libc.musl-x86_64.so.1',
-                '/lib/libcrypto.so.41',
-                '/lib/libssl.so.43',
-                '/lib/libz.so.1',
-                '/usr/lib/libffi.so.6',
-                '/usr/lib/libncursesw.so.6',
-                ]
-        else:
-            # Deps for generic Linux (currently Debian 7), sans paths.
-            allowed_deps=[
-                'libc.so.6',
-                'libcrypt.so.1',
-                'libcrypto.so.1.0.0',
-                'libdl.so.2',
-                'libffi.so.5',
-                'libm.so.6',
-                'libnsl.so.1',
-                'libpthread.so.0',
-                'libssl.so.1.0.0',
-                'libutil.so.1',
-                'libz.so.1',
-                'libgcc_s.so.1',
                 ]
     elif platform_system == 'aix':
         # List of deps with full paths for AIX 5.3 with OpenSSL 1.0.2k.


### PR DESCRIPTION
🚫 NOT TO BE MERGED WITH MASTER 🚫
------------------------------------------------

Scope
=====

In Trac ticket #5023, we updated `paver.sh` to build Debian-specific Python packages. But in production we are stuck with older packages, still using PyCrypto, more precisely revision `1afde4e1`.

Generate Debian-specific Python packages using PyCrypto to make it possible to move forward on this with the build slaves, `compat`, `server`, etc.

Changes
=======

Branched out from `1afde4e1` to still use PyCrypto: https://github.com/chevah/python-package/compare/1afde4e1...5084-debian-packages-with-pycrypto

Updated `paver.conf`, `paver.sh` and bits from `chevah_build.sh` and our own Python tests to make the builds on the `linux-*` slaves are green.

How to try and test the changes
===============================

reviewers: @adiroiban 

More of a FYI
