### PR TITLE
[#5124] Amazon Linux support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -464,7 +464,7 @@ check_dependencies() {
             packages=$DEBIAN_PKGS
             check_command='dpkg --status'
             ;;
-        rhel*)
+        rhel*|amazon*)
             packages=$RHEL_PKGS
             check_command='rpm --query'
             ;;

--- a/paver.sh
+++ b/paver.sh
@@ -641,7 +641,7 @@ detect_os() {
                     OS="archlinux"
                     ;;
                 *)
-                    echo "Unsupported Linux distribution type: $linux_distro."
+                    echo "Unsupported Linux distribution: $distro_fancy_name."
                     exit 15
                     ;;
             esac

--- a/paver.sh
+++ b/paver.sh
@@ -640,6 +640,12 @@ detect_os() {
                     # Arch Linux is a rolling distro, no version info available.
                     OS="archlinux"
                     ;;
+                "amzn")
+                    os_version_raw="$VERSION_ID"
+                    check_os_version "$distro_fancy_name" 2 \
+                        "$os_version_raw" os_version_chevah
+                    OS="amazon${os_version_chevah}"
+                    ;;
                 *)
                     echo "Unsupported Linux distribution: $distro_fancy_name."
                     exit 15

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -56,6 +56,31 @@ def get_allowed_deps():
                     '/lib64/libpcre.so.1',
                     '/lib64/libssl.so.10',
                     ])
+        elif ('amazon' in chevah_os):
+            # Deps for Amazon Linux 2 (x86_64 only).
+            allowed_deps=[
+                '/lib64/libcom_err.so.2',
+                '/lib64/libcrypto.so.10',
+                '/lib64/libcrypt.so.1',
+                '/lib64/libc.so.6',
+                '/lib64/libdl.so.2',
+                '/lib64/libffi.so.6',
+                '/lib64/libgssapi_krb5.so.2',
+                '/lib64/libk5crypto.so.3',
+                '/lib64/libkeyutils.so.1',
+                '/lib64/libkrb5.so.3',
+                '/lib64/libkrb5support.so.0',
+                '/lib64/libm.so.6',
+                '/lib64/libncursesw.so.6',
+                '/lib64/libpcre.so.1',
+                '/lib64/libpthread.so.0',
+                '/lib64/libresolv.so.2',
+                '/lib64/libselinux.so.1',
+                '/lib64/libssl.so.10',
+                '/lib64/libtinfo.so.6',
+                '/lib64/libutil.so.1',
+                '/lib64/libz.so.1',
+                ]
         elif ('sles' in chevah_os):
             sles_version = chevah_os[4:]
             # Common deps for SLES 11, 11SM and 12 w/ full paths (x86_64 only).


### PR DESCRIPTION
Scope
=====

Support for Amazon Linux 2.  Using ​https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-2-virtual-machine.html.


Changes
=======

Recognize `amzn` Linux distribution type.

Support Amazon Linux version 2 and newer.

**Drive-by fix**:
  * nicer exit message for unsupported Linux distros with `/etc/os-release` files.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review the simple changes.

Manually test on one of the new `amazon` slaves on Fiser and Ghindari, not yet integrated in our Buildbot setup. All tests pass with no changes other than the dep checks.