### PR TITLE
[#5131] Amazon Linux packages with PyCrypto.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -465,7 +465,7 @@ check_dependencies() {
             packages=$DEBIAN_PKGS
             check_command='dpkg --status'
             ;;
-        rhel*)
+        rhel*|amazon*)
             packages=$RHEL_PKGS
             check_command='rpm --query'
             ;;

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1:debian7@2.7.15.db42da13:sles@2.7.15.bfb4e344'
+PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1:debian7@2.7.15.db42da13:sles@2.7.15.bfb4e344:amazon2@2.7.15.f95a94ce'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -640,8 +640,14 @@ detect_os() {
                     # Arch Linux is a rolling distro, no version info available.
                     OS="archlinux"
                     ;;
+                "amzn")
+                    os_version_raw="$VERSION_ID"
+                    check_os_version "$distro_fancy_name" 2 \
+                        "$os_version_raw" os_version_chevah
+                    OS="amazon${os_version_chevah}"
+                    ;;
                 *)
-                    echo "Unsupported Linux distribution type: $linux_distro."
+                    echo "Unsupported Linux distribution: $distro_fancy_name."
                     exit 15
                     ;;
             esac

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -56,6 +56,31 @@ def get_allowed_deps():
                     '/lib64/libpcre.so.1',
                     '/lib64/libssl.so.10',
                     ])
+        elif ('amazon' in chevah_os):
+            # Deps for Amazon Linux 2 (x86_64 only).
+            allowed_deps=[
+                '/lib64/libcom_err.so.2',
+                '/lib64/libcrypto.so.10',
+                '/lib64/libcrypt.so.1',
+                '/lib64/libc.so.6',
+                '/lib64/libdl.so.2',
+                '/lib64/libffi.so.6',
+                '/lib64/libgssapi_krb5.so.2',
+                '/lib64/libk5crypto.so.3',
+                '/lib64/libkeyutils.so.1',
+                '/lib64/libkrb5.so.3',
+                '/lib64/libkrb5support.so.0',
+                '/lib64/libm.so.6',
+                '/lib64/libncursesw.so.6',
+                '/lib64/libpcre.so.1',
+                '/lib64/libpthread.so.0',
+                '/lib64/libresolv.so.2',
+                '/lib64/libselinux.so.1',
+                '/lib64/libssl.so.10',
+                '/lib64/libtinfo.so.6',
+                '/lib64/libutil.so.1',
+                '/lib64/libz.so.1',
+                ]
         elif ('sles' in chevah_os):
             sles_version = chevah_os[4:]
             # Common deps for SLES 11, 11SM and 12 w/ full paths (x86_64 only).


### PR DESCRIPTION
🚫 NOT TO BE MERGED WITH MASTER 🚫
------------------------------------------------

Scope
=====

In #121 , we got support for Amazon Linux 2. But in production we are stuck with older packages, still using PyCrypto, more precisely revision `1afde4e1`.

Generate Amazon Linux 2 Python packages with PyCrypto for `server`.

Changes
=======

Branched out from #120 to use PyCrypto.

Cherry-picked the changes in #121 for Amazon Linux support.


How to try and test the changes
===============================

reviewers: @adiroiban 

More of a FYI and to know were to get specific revision for Amazon Linux 2.
