### PR TITLE
[#5168] Alpine 3.7 support.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -496,7 +496,7 @@ check_dependencies() {
             ;;
         alpine*)
             packages=$ALPINE_PKGS
-            check_command='apk info'
+            check_command=apk_shim
             ;;
         archlinux)
             packages=$ARCH_PKGS

--- a/functions.sh
+++ b/functions.sh
@@ -327,3 +327,11 @@ add_ignored_safety_ids_for_pyopenssl_false_positives() {
     #     of service if memory runs low or is exhausted."
     SAFETY_FALSE_POSITIVES_OPTS="$SAFETY_FALSE_POSITIVES_OPTS -i 36533 -i 36534"
 }
+
+#
+# Alpine's apk doesn't seem to have a check for installed packages individually.
+#
+apk_shim() {
+    pkg="$1"
+    apk info | grep -q ^"$pkg"$
+}

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.15.1afde4e1:solaris10@2.7.8.1afde4e1'
+PYTHON_CONFIGURATION='default@2.7.15.1a51041c:solaris10@2.7.8.1a51041c'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'


### PR DESCRIPTION
Scope
=====

There's not much left until 2019-05-01, the end of support date for Alpine Linux 3.6, according to ​https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases.

While at it, see what's with the `no_aes` Alpine slaves, which seem completely unused, wasting RAM.

Changes
=======

`salt-master` fixes were done as a drive-by in https://github.com/chevah/salt-master/pull/413.

I left the Alpine 3.6 slave alone for now.

Updated the `no_aes` Alpiine slave on Lotu to 3.7. There seem to be less persistent issues now when testing server: https://chevah.com/buildbot/builders/server-alpine-37/builds/3/steps/test/logs/stdio

For the other `no_aes` Alpine slave on Neaua I chose to reinstall with the _Standard_ install disk, not the _Virtual_ one. There seem to be one less persistent issue here: https://chevah.com/buildbot/builders/server-alpine-37/builds/2/steps/test/logs/stdio

**Drive-by fixes**:
  * fixed package checking with Alpine's `apk`.


How to try and test the changes
===============================

reviewers: @adiroiban 

Check the drive-by fix in changes.

Check the issues with the Alpine 3.7 _standard_ and _virtual_ installations referenced above and decide on what to do next.