### PR TITLE
[#5180] Build psutil on supported platforms.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -144,8 +144,8 @@ COMMON_PKGS="gcc make m4 automake libtool texinfo patch"
 COMMON_SLES_PKGS="$COMMON_PKGS git-core zlib-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS git libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
 RHEL_PKGS="$COMMON_PKGS git openssl-devel zlib-devel libffi-devel ncurses-devel"
-ALPINE_PKGS="\
-    $COMMON_PKGS git libc-dev libressl-dev zlib-dev libffi-dev ncurses-dev"
+ALPINE_PKGS="$COMMON_PKGS\
+    git libc-dev libressl-dev zlib-dev libffi-dev ncurses-dev linux-headers"
 ARCH_PKGS="$COMMON_PKGS git libffi ncurses"
 case "$OS" in
     rhel5)

--- a/chevah_build
+++ b/chevah_build
@@ -220,6 +220,16 @@ case $OS in
         export BUILD_LIBFFI="yes"
         # libedit requires __STDC_ISO_10646__.
         export BUILD_LIBEDIT="no"
+        if [ "${OS%aix53}" = "" ]; then
+            # psutil doesn't build on AIX 5.3, so we do without it.
+            PIP_LIBRARIES="\
+                setproctitle==${SETPROCTITLE_VERSION} \
+                pycryptodomex==${PYCRYPTODOMEX_VERSION} \
+                cryptography==${CRYPTOGRAPHY_VERSION} \
+                pyOpenSSL==${PYOPENSSL_VERSION} \
+                scandir==${SCANDIR_VERSION} \
+                "
+        fi
         ;;
     solaris*)
         # By default, we use Sun's Studio compiler. Comment these two for GCC.
@@ -339,14 +349,19 @@ case $OS in
         # which is then needed by gmpy 1.x
         export BUILD_LIBFFI="yes"
         export BUILD_ZLIB="yes"
+        # libedit requires __STDC_ISO_10646__.
+        export BUILD_LIBEDIT="no"
         # CFFI/cryptography build on HP-UX, but libffi breaks for CFFI. More at
         # https://bitbucket.org/cffi/cffi/issues/368/segmentation-fault-in-hp-ux
         export BUILD_CFFI="no"
         add_ignored_safety_ids_for_pyopenssl_false_positives
-        PIP_LIBRARIES=$PIP_LIBRARIES_NO_CFFI
+        # PIP_LIBRARIES_NO_CFFI without psutil, as it doesn't build in HP-UX.
+        PIP_LIBRARIES="\
+            pyOpenSSL==0.13.1 \
+            setproctitle==${SETPROCTITLE_VERSION} \
+            scandir==${SCANDIR_VERSION} \
+            "
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
-        # libedit requires __STDC_ISO_10646__.
-        export BUILD_LIBEDIT="no"
         ;;
     osx*)
         # The extra params needed to set the minimum target version to 10.8

--- a/chevah_build
+++ b/chevah_build
@@ -39,9 +39,10 @@ PYOPENSSL_VERSION="18.0.0"
 CRYPTOGRAPHY_VERSION="2.4.2"
 SETPROCTITLE_VERSION="1.1.10"
 SCANDIR_VERSION="1.9.0"
+PSUTIL_VERSION="5.4.8"
+PYWIN32_VERSION="223"
 GMPY2_VERSION="2.0.8"
 GMPY_VERSION="1.17"
-PYWIN32_VERSION="223"
 
 # pycparser needs to be explicitly installed to work around setuptools auto
 # dependencies.
@@ -81,6 +82,7 @@ PIP_LIBRARIES="\
     cryptography==${CRYPTOGRAPHY_VERSION} \
     pyOpenSSL==${PYOPENSSL_VERSION} \
     scandir==${SCANDIR_VERSION} \
+    psutil==${PSUTIL_VERSION} \
     "
 # cryptography 1.3.4 was last upstream version to support OpenSSL 0.9.8.
 # pyOpenSSL 16.0.0 was last upstream version to support OpenSSL 0.9.8.
@@ -90,6 +92,7 @@ PIP_LIBRARIES_OPENSSL_098="\
     cryptography==1.3.4 \
     pyOpenSSL==16.0.0 \
     scandir==${SCANDIR_VERSION} \
+    psutil==${PSUTIL_VERSION} \
     "
 # Python modules installed through pip on systems not built around cffi.
 # pyOpenSSL 0.13.1 was last upstream version before the port to
@@ -99,6 +102,7 @@ PIP_LIBRARIES_NO_CFFI="\
     pyOpenSSL==0.13.1 \
     setproctitle==${SETPROCTITLE_VERSION} \
     scandir==${SCANDIR_VERSION} \
+    psutil==${PSUTIL_VERSION} \
     "
 
 # Arguments that are sent when using pip.
@@ -359,6 +363,7 @@ case $OS in
             cryptography==${CRYPTOGRAPHY_VERSION}upstream \
             pyOpenSSL==${PYOPENSSL_VERSION} \
             scandir==${SCANDIR_VERSION} \
+            psutil==${PSUTIL_VERSION} \
             "
         ;;
     macos*)
@@ -394,6 +399,7 @@ case $OS in
             cryptography==${CRYPTOGRAPHY_VERSION} \
             pyOpenSSL==${PYOPENSSL_VERSION} \
             scandir==${SCANDIR_VERSION} \
+            psutil==${PSUTIL_VERSION} \
             "
         ;;
     rhel5|sles11)
@@ -409,6 +415,7 @@ case $OS in
             cryptography==${CRYPTOGRAPHY_VERSION}upstream \
             pyOpenSSL==${PYOPENSSL_VERSION} \
             scandir==${SCANDIR_VERSION} \
+            psutil==${PSUTIL_VERSION} \
             "
         ;;
     sles10)

--- a/chevah_build
+++ b/chevah_build
@@ -439,6 +439,11 @@ case $OS in
         PIP_LIBRARIES=$PIP_LIBRARIES_NO_CFFI
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
+    debian*)
+        # Build here as portable as possible, akin to the old generic Linux.
+        export BUILD_LIBFFI="yes"
+        export BUILD_LIBEDIT="no"
+        ;;
     windows*)
         # On Windows, python executable is installed at a different path.
         LOCAL_PYTHON_BINARY=./$LOCAL_PYTHON_BINARY_DIST/lib/python

--- a/chevah_build
+++ b/chevah_build
@@ -130,8 +130,7 @@ ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 
 # List of OS packages required for building Python/pyOpenSSL/cryptography etc.
 # Lately we don't install anything automatically, we just check for the
-# presence of required packages on everything but AIX, HP-UX, macOS, OS X,
-# Solaris, Windows and generic Linux builds.
+# presence of required packages. Or at least of the required commands...
 # This build of Python / pyOpenSSL / cryptography / etc.  requires:
 # a C compiler, make, m4, libs and headers for OpenSSL / zlib / libffi,
 # git (for patching Python's version), patch (for applying our own patches),
@@ -139,7 +138,7 @@ ARCH=`cut -d' ' -f 4 DEFAULT_VALUES`
 # To build libedit for the readline module, we need the headers of
 # a curses library, automake and libtool.
 # On platforms with a choice of C compilers, you may choose among the
-# available compilers by setting CC and CXX further in this script.
+# available compilers by setting CC and CXX further down in this script.
 COMMON_PKGS="gcc make m4 automake libtool texinfo patch"
 COMMON_SLES_PKGS="$COMMON_PKGS git-core zlib-devel ncurses-devel"
 DEBIAN_PKGS="$COMMON_PKGS git libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
@@ -355,7 +354,7 @@ case $OS in
         # https://bitbucket.org/cffi/cffi/issues/368/segmentation-fault-in-hp-ux
         export BUILD_CFFI="no"
         add_ignored_safety_ids_for_pyopenssl_false_positives
-        # PIP_LIBRARIES_NO_CFFI without psutil, as it doesn't build in HP-UX.
+        # PIP_LIBRARIES_NO_CFFI without psutil, which doesn't support HP-UX.
         PIP_LIBRARIES="\
             pyOpenSSL==0.13.1 \
             setproctitle==${SETPROCTITLE_VERSION} \
@@ -440,7 +439,7 @@ case $OS in
         EXTRA_LIBRARIES=$EXTRA_LIBRARIES_NO_CFFI
         ;;
     debian*)
-        # Build here as portable as possible, akin to the old generic Linux.
+        # Build as portable as possible, akin to the old generic Linux builds.
         export BUILD_LIBFFI="yes"
         export BUILD_LIBEDIT="no"
         ;;

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -854,7 +854,9 @@ def main():
             exit_code = 18
 
     # Some OS'es are not supported by upstream psutil.
-    # Windows is special. We build on XP, but XP/2003 not supported any more.
+	# FIXME:5185:
+    # Windows is special. We build python-package on XP, with psutil as wheel,
+	# but XP/2003 not supported any more upstream, so we can't test for it.
     if not chevah_os in [ 'aix53', 'hpux1131', 'windows' ]:
         try:
             import psutil

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -750,13 +750,6 @@ def main():
         exit_code = 17
 
     try:
-        import psutil
-        print 'psutil %s' % (psutil.__version__,)
-    except:
-        sys.stderr.write('"psutil" missing.\n')
-        exit_code = 23
-
-    try:
         import gmpy2
         print 'gmpy2 %s with:' % (gmpy2.version())
         print '\tMP (Multiple-precision library) - %s' % (gmpy2.mp_version())
@@ -851,6 +844,14 @@ def main():
             sys.stderr.write('"_scandir" missing.\n')
             exit_code = 18
 
+    # Some OS'es are not supported by upstream psutil.
+    if not chevah_os in [ 'aix53', 'hpux1131' ]:
+        try:
+            import psutil
+            print 'psutil %s' % (psutil.__version__,)
+        except:
+            sys.stderr.write('"psutil" missing.\n')
+            exit_code = 23
 
     if ( platform_system == 'linux' ) or ( platform_system == 'sunos' ):
         try:

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -854,9 +854,9 @@ def main():
             exit_code = 18
 
     # Some OS'es are not supported by upstream psutil.
-	# FIXME:5185:
-    # Windows is special. We build python-package on XP, with psutil as wheel,
-	# but XP/2003 not supported any more upstream, so we can't test for it.
+    # FIXME:5185:
+    # Windows is special. We build python-package on XP, with psutil as a wheel,
+    # but XP/2003 not supported any more upstream, so we can't test for it.
     if not chevah_os in [ 'aix53', 'hpux1131', 'windows' ]:
         try:
             import psutil

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -854,7 +854,8 @@ def main():
             exit_code = 18
 
     # Some OS'es are not supported by upstream psutil.
-    if not chevah_os in [ 'aix53', 'hpux1131' ]:
+    # Windows is special. We build on XP, but XP/2003 not supported any more.
+    if not chevah_os in [ 'aix53', 'hpux1131', 'windows' ]:
         try:
             import psutil
             print 'psutil %s' % (psutil.__version__,)

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -210,8 +210,10 @@ def get_allowed_deps():
             allowed_deps=[
                 '/lib/ld-musl-x86_64.so.1',
                 '/lib/libc.musl-x86_64.so.1',
-                '/lib/libcrypto.so.41',
-                '/lib/libssl.so.43',
+                '/lib/libssl.so.44',
+                '/lib/libcrypto.so.42.0.0',
+                '/lib/libssl.so.44.0.1',
+                '/lib/libcrypto.so.42',
                 '/lib/libz.so.1',
                 '/usr/lib/libffi.so.6',
                 '/usr/lib/libncursesw.so.6',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -264,9 +264,15 @@ def get_allowed_deps():
         # sys.platform could be 'aix5', 'aix6' etc.
         aix_version = int(sys.platform[-1])
         if aix_version >= 6:
-            # Specific deps to add for AIX 6.1 and 7.1.
+            # Specific deps to add for AIX 6.1 and 7.1, mostly psutil deps.
             allowed_deps.extend([
                 '/lib/libthread.a(shr.o)',
+                '/usr/lib/libcfg.a(shr.o)',
+                '/usr/lib/libcorcfg.a(shr.o)',
+                '/usr/lib/liblvm.a(shr.o)',
+                '/usr/lib/libodm.a(shr.o)',
+                '/usr/lib/libperfstat.a(shr.o)',
+                '/usr/lib/libsrc.a(shr.o)',
                 ])
     elif platform_system == 'sunos':
         # On Solaris, platform.release() can be: '5.9'. '5.10', '5.11' etc.
@@ -279,6 +285,7 @@ def get_allowed_deps():
                 '/lib/64/libm.so.2',
                 '/lib/64/libnsl.so.1',
                 '/lib/64/libsocket.so.1',
+                '/usr/lib/64/libkstat.so.1',
                 ]
             if solaris_version == '10':
                 # Specific deps to add for Solaris 10.
@@ -347,6 +354,7 @@ def get_allowed_deps():
             allowed_deps = [
                 '/lib/libc.so.1',
                 '/lib/libdl.so.1',
+                '/lib/libkstat.so.1',
                 '/lib/libm.so.2',
                 '/lib/libnsl.so.1',
                 '/lib/libsocket.so.1',
@@ -436,6 +444,7 @@ def get_allowed_deps():
             '/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon',
             '/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation',
             '/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices',
+            '/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit',
             '/System/Library/Frameworks/Security.framework/Versions/A/Security',
             '/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration',
             '/usr/lib/libffi.dylib',
@@ -462,6 +471,7 @@ def get_allowed_deps():
         allowed_deps = [
             '/lib/libc.so.7',
             '/lib/libcrypt.so.5',
+            '/lib/libdevstat.so.7',
             '/lib/libm.so.5',
             '/lib/libncurses.so.8',
             '/lib/libthr.so.3',
@@ -474,12 +484,16 @@ def get_allowed_deps():
             # Additional deps, specific for FreeBSD 10.
             allowed_deps.extend([
                 '/lib/libcrypto.so.7',
+                '/lib/libkvm.so.6',
                 '/usr/lib/libssl.so.7',
             ])
         else:
             # Additional deps, specific for FreeBSD 11 and maybe newer.
             allowed_deps.extend([
                 '/lib/libcrypto.so.8',
+                '/lib/libelf.so.2',
+                '/lib/libkvm.so.7',
+                '/usr/lib/libdl.so.1',
                 '/usr/lib/libssl.so.8',
             ])
     elif platform_system == 'openbsd':
@@ -488,6 +502,7 @@ def get_allowed_deps():
             '/usr/lib/libc.so',
             '/usr/lib/libcrypto.so',
             '/usr/lib/libcurses.so',
+            '/usr/lib/libkvm.so',
             '/usr/lib/libm.so',
             '/usr/lib/libpthread.so',
             '/usr/lib/libssl.so',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -154,24 +154,20 @@ def get_allowed_deps():
                     '/usr/lib/aarch64-linux-gnu/libffi.so.6',
                     ]
         elif ('debian' in chevah_os):
-            # Full deps for Debian 7.x amd64.
+            # Full deps for Debian 7.x/8.x amd64.
             allowed_deps=[
                 '/lib/x86_64-linux-gnu/libcrypt.so.1',
                 '/lib/x86_64-linux-gnu/libc.so.6',
                 '/lib/x86_64-linux-gnu/libdl.so.2',
-                '/lib/x86_64-linux-gnu/libgcc_s.so.1',
                 '/lib/x86_64-linux-gnu/libm.so.6',
-                '/lib/x86_64-linux-gnu/libncurses.so.5',
                 '/lib/x86_64-linux-gnu/libpthread.so.0',
-                '/lib/x86_64-linux-gnu/libtinfo.so.5',
                 '/lib/x86_64-linux-gnu/libutil.so.1',
                 '/lib/x86_64-linux-gnu/libz.so.1',
                 '/usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0',
-                '/usr/lib/x86_64-linux-gnu/libffi.so.5',
                 '/usr/lib/x86_64-linux-gnu/libssl.so.1.0.0',
                 ]
             if 'x86' in chevah_arch:
-                # Full deps for Debian 7.x i386.
+                # Full deps for Debian 7.x/8.x i386.
                 allowed_deps=[
                     '/lib/i386-linux-gnu/i686/cmov/libc.so.6',
                     '/lib/i386-linux-gnu/i686/cmov/libcrypt.so.1',
@@ -179,13 +175,9 @@ def get_allowed_deps():
                     '/lib/i386-linux-gnu/i686/cmov/libm.so.6',
                     '/lib/i386-linux-gnu/i686/cmov/libpthread.so.0',
                     '/lib/i386-linux-gnu/i686/cmov/libutil.so.1',
-                    '/lib/i386-linux-gnu/libgcc_s.so.1',
-                    '/lib/i386-linux-gnu/libncurses.so.5',
-                    '/lib/i386-linux-gnu/libtinfo.so.5',
                     '/lib/i386-linux-gnu/libz.so.1',
                     '/usr/lib/i386-linux-gnu/i686/cmov/libcrypto.so.1.0.0',
                     '/usr/lib/i386-linux-gnu/i686/cmov/libssl.so.1.0.0',
-                    '/usr/lib/i386-linux-gnu/libffi.so.5',
                     ]
         elif ('raspbian' in chevah_os):
             # Common deps with full paths for Raspbian 7 and 8.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -750,6 +750,13 @@ def main():
         exit_code = 17
 
     try:
+        import psutil
+        print 'psutil %s' % (psutil.__version__,)
+    except:
+        sys.stderr.write('"psutil" missing.\n')
+        exit_code = 23
+
+    try:
         import gmpy2
         print 'gmpy2 %s with:' % (gmpy2.version())
         print '\tMP (Multiple-precision library) - %s' % (gmpy2.mp_version())


### PR DESCRIPTION
Scope
=====

Adding `psutil` support.


Changes
=======

Build `psutil` everywhere except:

  * Windows, where we use the upstream wheel
  * HP-UX, for which there is no support from uppstream
  * AIX 5.3, where the build fails.

**Drive-by fixes**:
 * updated deps for Alpine 3.7 and Debian 8
 * build Debian packages as portable as possible, there might be of some use on other unsupported Linux platforms. This means no `readline` module on Debian.

How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.

Run the automated tests.