### PR TITLE
[#5265] OpenBSD 6.5 cryptography build fix.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -402,12 +402,7 @@ case $OS in
         # Beware that zlib headers are not present either on macOS 10.14.
         # We don't care here because we build on 10.13.
         ;;
-    freebsd*)
-        export CC="clang"
-        export CXX="clang++"
-        export BUILD_LIBFFI="yes"
-        ;;
-    openbsd*)
+    freebsd*|openbsd*)
         export CC="clang"
         export CXX="clang++"
         export BUILD_LIBFFI="yes"

--- a/chevah_build
+++ b/chevah_build
@@ -402,10 +402,28 @@ case $OS in
         # Beware that zlib headers are not present either on macOS 10.14.
         # We don't care here because we build on 10.13.
         ;;
-    freebsd*|openbsd*)
+    freebsd*)
         export CC="clang"
         export CXX="clang++"
         export BUILD_LIBFFI="yes"
+        ;;
+    openbsd*)
+        export CC="clang"
+        export CXX="clang++"
+        export BUILD_LIBFFI="yes"
+        if [ "$OS" = "openbsd65" ]; then
+            # Latest cryptography (2.6.1) fails to build on OpenBSD 6.5.
+            PIP_LIBRARIES="\
+                setproctitle==${SETPROCTITLE_VERSION} \
+                pycryptodomex==${PYCRYPTODOMEX_VERSION} \
+                cryptography==${CRYPTOGRAPHY_VERSION}obsd65 \
+                pyOpenSSL==${PYOPENSSL_VERSION} \
+                scandir==${SCANDIR_VERSION} \
+                psutil==${PSUTIL_VERSION} \
+                Cython==${CYTHON_VERSION} \
+                subprocess32==${SUBPROCESS32_VERSION} \
+                "
+        fi
         ;;
     sles12)
         # SLES's libffi headers from SDK do not match default-available package.

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
 BASE_REQUIREMENTS='chevah-brink==0.70.3 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.16.690bed90:solaris10@2.7.8.690bed90'
+PYTHON_CONFIGURATION='default@2.7.16.9c55c222:solaris10@2.7.8.9c55c222:openbsd65@2.7.16.88f7a189'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'


### PR DESCRIPTION
Scope
=====

Cryptography fails to build on OpenBSD 6.5.

High prio, because I have upgraded to 6.5 and can't use paver stuff locally.


Changes
=======

Used the  OpenBSD -current  patches for `cryptography` 2.6.1 to build a special tarball to be used on OpenBSD 6.5

**Drive-by changes**:
  * updated paver stuff.

How to try and test the changes
===============================

reviewers: **WIP**

Please review changes.

Run the tests.