### PR TITLE
[#5286] Cryptography 2.7 update. HP-UX fixes.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -36,7 +36,7 @@ PYCRYPTO_VERSION="2.6.1"
 SAFETY_FALSE_POSITIVES_OPTS="-i 35015"
 PYCRYPTODOMEX_VERSION="3.6.6"
 PYOPENSSL_VERSION="19.0.0"
-CRYPTOGRAPHY_VERSION="2.6.1"
+CRYPTOGRAPHY_VERSION="2.7"
 SETPROCTITLE_VERSION="1.1.10"
 SCANDIR_VERSION="1.10.0"
 PSUTIL_VERSION="5.6.1"
@@ -420,21 +420,8 @@ case $OS in
     freebsd*|openbsd*)
         export CC="clang"
         export CXX="clang++"
+        # libffi not available in the base systems, only as port/package.
         export BUILD_LIBFFI="yes"
-        if [ "$OS" = "openbsd65" ]; then
-            # Latest cryptography (2.6.1) fails to build on OpenBSD 6.5.
-            PIP_LIBRARIES="\
-                setproctitle==${SETPROCTITLE_VERSION} \
-                pycryptodomex==${PYCRYPTODOMEX_VERSION} \
-                cryptography==${CRYPTOGRAPHY_VERSION}obsd65 \
-                pyOpenSSL==${PYOPENSSL_VERSION} \
-                scandir==${SCANDIR_VERSION} \
-                psutil==${PSUTIL_VERSION} \
-                Cython==${CYTHON_VERSION} \
-                subprocess32==${SUBPROCESS32_VERSION} \
-                bcrypt==${BCRYPT_VERSION} \
-                "
-        fi
         ;;
     sles12)
         # SLES's libffi headers from SDK do not match default-available package.

--- a/chevah_build
+++ b/chevah_build
@@ -116,7 +116,6 @@ PIP_LIBRARIES_NO_CFFI="\
     scandir==${SCANDIR_VERSION} \
     Cython==${CYTHON_VERSION} \
     subprocess32==${SUBPROCESS32_VERSION} \
-    bcrypt==${BCRYPT_VERSION} \
     "
 
 # Arguments that are sent when using pip.

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -723,7 +723,7 @@ def main():
             from cryptography.hazmat.backends.openssl.backend import backend
             import cryptography
             openssl_version = backend.openssl_version_text()
-            if chevah_os in [ "windows", "osx108", "sles11", "rhel5" ]:
+            if chevah_os in [ "windows", "osx", "sles11", "rhel5" ]:
                 # Check OpenSSL version from upstream wheels.
                 expecting = u'OpenSSL 1.1.1c  28 May 2019'
                 if openssl_version != expecting:

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -842,20 +842,21 @@ def main():
     else:
         print '"subprocess32" module is present.'
 
-    try:
-        import bcrypt
-        password = b"super secret password"
-        # Hash the password with a randomly-generated salt.
-        hashed = bcrypt.hashpw(password, bcrypt.gensalt())
-        # Check that an unhashed password matches hashed one.
-        if bcrypt.checkpw(password, hashed):
-            print 'bcrypt %s' % (bcrypt.__version__,)
-        else:
-            sys.stderr.write('"bcrypt" present, but broken.\n')
-            exit_code = 27
-    except:
-        sys.stderr.write('"bcrypt" missing.\n')
-        exit_code = 26
+    if not platform_system == 'hp-ux':
+        try:
+            import bcrypt
+            password = b"super secret password"
+            # Hash the password with a randomly-generated salt.
+            hashed = bcrypt.hashpw(password, bcrypt.gensalt())
+            # Check that an unhashed password matches hashed one.
+            if bcrypt.checkpw(password, hashed):
+                print 'bcrypt %s' % (bcrypt.__version__,)
+            else:
+                sys.stderr.write('"bcrypt" present, but broken.\n')
+                exit_code = 27
+        except:
+            sys.stderr.write('"bcrypt" missing.\n')
+            exit_code = 26
 
     # Windows specific modules.
     if os.name == 'nt':

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -725,7 +725,7 @@ def main():
             openssl_version = backend.openssl_version_text()
             if chevah_os in [ "windows", "osx108", "sles11", "rhel5" ]:
                 # Check OpenSSL version from upstream wheels.
-                expecting = u'OpenSSL 1.1.1b  26 Feb 2019'
+                expecting = u'OpenSSL 1.1.1c  28 May 2019'
                 if openssl_version != expecting:
                     sys.stderr.write('Expecting %s, got %s.\n' % (
                         expecting, openssl_version))


### PR DESCRIPTION
Scope
=====

Fix HP-UX build, the work in #132 broke it a couple of ways.

 While at it, update cryptography to 2.7 for CVE-2019-1543, fixed in OpenSSL 1.1.1c.


Changes
=======

Fixed HP-UX build to not build or test `bcrypt` package.

Updated `cryptography` to latest stable version, 2.7.

Uploaded 2.7 `cryptography` source package and wheels for Windows / OS X / SLES 11 on binary server.


How to try and test the changes
===============================

reviewers:  @adiroiban 

Please review changes.

Run the automated tests. For ALL slaves. :-]