### PR TITLE
Fixed publishing on Windows.

### DIFF
--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -72,7 +72,6 @@ jobs:
         ./chevah_build compat
 
     # Upload using a (per-OS selected) sftp command, then show final links.
-    # Remove key in same step to have it deleted even if publishing fails.
     - name: Upload testing package
       run: |
         mkdir -pv ~/.ssh/
@@ -81,7 +80,8 @@ jobs:
         chmod 600 priv_key
         echo "${{ secrets.SFTPPLUS_BIN_PRIV_KEY }}" > priv_key
         echo "${{ secrets.SFTPPLUS_BIN_HOST_KEY }}" > ~/.ssh/known_hosts
-        ./publish_dist.sh ; rm priv_key
+        ./publish_dist.sh
+        rm priv_key
 
     # If one of the above steps fails, fire up tmate for remote debugging.
     - name: Tmate debug on failure
@@ -150,7 +150,8 @@ jobs:
         chmod 600 priv_key
         echo "${{ secrets.SFTPPLUS_BIN_PRIV_KEY }}" > priv_key
         echo "${{ secrets.SFTPPLUS_BIN_HOST_KEY }}" > ~/.ssh/known_hosts
-        ./publish_dist.sh ; rm priv_key
+        ./publish_dist.sh
+        rm priv_key
 
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'
@@ -214,7 +215,6 @@ jobs:
     # which is more finicky in regards to file permissions.
     # Beware the commands in this step run under PowerShell.
     - name: Prepare SFTP upload
-      shell: powershell
       run: |
         mkdir -p ~/.ssh/
         cd python-package/
@@ -226,7 +226,11 @@ jobs:
         choco install --yes --no-progress openssh
 
     - name: Upload testing package
-      run: bash -c 'cd python-package; ./publish_dist.sh ; rm priv_key'
+      shell: bash
+      run: |
+        cd python-package
+        ./publish_dist.sh
+        rm priv_key
 
     - name: Tmate debug on failure
       if: failure() && env.TMATE_DEBUG == 'yes'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -113,7 +113,6 @@ jobs:
     #    su chevah -lc "umask 002; cd /home/chevah/python-package; ./chevah_build compat"
 
     # Using `~/` is problematic under Docker, use `/root/`.
-    # Remove key in same step to avoid leaving it on disk if publishing fails.
     - name: Upload testing package
       run: |
         mkdir -pv /root/.ssh/
@@ -122,4 +121,5 @@ jobs:
         chmod 600 priv_key
         echo "${{ secrets.SFTPPLUS_BIN_PRIV_KEY }}" > priv_key
         echo "${{ secrets.SFTPPLUS_BIN_HOST_KEY }}" > /root/.ssh/known_hosts
-        ./publish_dist.sh ; rm priv_key
+        ./publish_dist.sh
+        rm priv_key


### PR DESCRIPTION
Scope
=====

Publishing on Windows was broken by a "cosmetic" change.


Changes
=======

Switch back to the old sequence of commands for publishing on Windows.

**Drive-by fix**:
  * Actually fail when publishing a package fails. At the expense of leaving private keys behind on disk.


How to try and test the changes
===============================

reviewers: **WIP**
