### PR TITLE
Minor AIX-related fixes.

### DIFF
--- a/chevah_build
+++ b/chevah_build
@@ -494,7 +494,7 @@ command_build() {
                 build/openssl-${OPENSSL_VERSION}/include/openssl \
                 ${INSTALL_FOLDER}/include/
             # To make sure they're found, we're back to using CPPFLAGS.
-            export CPPFLAGS="$CPPFLAGS -I${INSTALL_FOLDER}/include"
+            export CPPFLAGS="${CPPFLAGS:-} -I${INSTALL_FOLDER}/include"
         fi
     else
         (>&2 echo "Skip building OpenSSL!")

--- a/chevah_build
+++ b/chevah_build
@@ -694,6 +694,8 @@ command_test() {
 
     echo '##### Testing for outdated packages and security issues... #####'
     execute $PYTHON_BIN -m pip list --outdated --format=columns
+    # Safety needs PyYAML, which needs Cython, which needs to be built on AIX.
+    aix_ld_hack init
     execute $PYTHON_BIN -m pip install $PIP_ARGS safety==1.8.7
     execute $PYTHON_BIN -m safety check --full-report \
         $SAFETY_FALSE_POSITIVES_OPTS $SAFETY_IGNORED_OPTS
@@ -709,6 +711,7 @@ command_test() {
         (>&2 echo "Following Safety DB IDs were excepted from checks:")
         (>&2 echo "${SAFETY_IGNORED_IDS}")
     fi
+    aix_ld_hack cleanup
     # Avoid having output messages sometimes mangled for some reason.
     sleep 1
 

--- a/chevah_build
+++ b/chevah_build
@@ -236,7 +236,7 @@ case $OS in
         export CXX="clang++"
         export MAKE="make"
         # Build as compatible as it makes sense. See brink.sh for the reason.
-        export CFLAGS="$CFLAGS -mmacosx-version-min=10.12"
+        export CFLAGS="${CFLAGS:-} -mmacosx-version-min=10.12"
         # setup.py skips building readline by default, as it sets this to
         # "10.4", and then tries to avoid the broken readline in OS X 10.4.
         export MACOSX_DEPLOYMENT_TARGET=10.12
@@ -322,7 +322,7 @@ if [ "${OS%sol*}" = "" ]; then
 elif [ "${OS%fbsd*}" = "" -o "${OS%obsd*}" = "" ]; then
     # Use PIC (Position Independent Code) on FreeBSD and OpenBSD with Clang.
     export CFLAGS="${CFLAGS:-} -fPIC"
-elif [ "$CC" = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
+elif [ ${CC:-} = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
     # Use PIC (Position Independent Code) with GCC on 64-bit arches.
     export CFLAGS="${CFLAGS:-} -fPIC"
 fi

--- a/chevah_build
+++ b/chevah_build
@@ -6,6 +6,10 @@
 # test
 # compat (for the compat repo tests)
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 PYTHON_BUILD_VERSION="2.7.18"
 LIBFFI_VERSION="3.2.1"
 ZLIB_VERSION="1.2.11"
@@ -310,17 +314,17 @@ esac
 if [ "${OS%sol*}" = "" ]; then
     if [ ${ARCH} = "sparc64" ]; then
         # Required for compiling GMP on Solaris for SPARC with Sun Studio.
-        export CFLAGS="$CFLAGS -xcode=abs64"
+        export CFLAGS="${CFLAGS:-} -xcode=abs64"
     elif [ ${ARCH} = "x64" -a "${OS%sol11*}" = "" ]; then
         # Not all packages enable PIC, we force it to avoid relocation issues.
-        export CFLAGS="$CFLAGS -Kpic"
+        export CFLAGS="${CFLAGS:-} -Kpic"
     fi
 elif [ "${OS%fbsd*}" = "" -o "${OS%obsd*}" = "" ]; then
     # Use PIC (Position Independent Code) on FreeBSD and OpenBSD with Clang.
-    export CFLAGS="${CFLAGS} -fPIC"
+    export CFLAGS="${CFLAGS:-} -fPIC"
 elif [ "$CC" = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
     # Use PIC (Position Independent Code) with GCC on 64-bit arches.
-    export CFLAGS="${CFLAGS} -fPIC"
+    export CFLAGS="${CFLAGS:-} -fPIC"
 fi
 
 # Parallel builds where applicable.
@@ -440,8 +444,8 @@ command_build() {
     # We used to add the new include path to $CPPFLAGS, but it's not as portable
     # as copying the includes (HP-UX's linker fails with -I when not using GCC).
     mkdir -p $INSTALL_FOLDER/{include,lib}
-    export LDFLAGS="-L${INSTALL_FOLDER}/lib/ ${LDFLAGS}"
-    export PKG_CONFIG_PATH="${INSTALL_FOLDER}/lib/pkgconfig/:${PKG_CONFIG_PATH}"
+    export LDFLAGS="-L${INSTALL_FOLDER}/lib/ ${LDFLAGS:-}"
+    export PKG_CONFIG_PATH="$INSTALL_FOLDER/lib/pkgconfig/:${PKG_CONFIG_PATH:-}"
 
     if [ "$BUILD_LIBFFI" = "yes" ]; then
         build 'libffi' "libffi-$LIBFFI_VERSION" ${PYTHON_BUILD_FOLDER}
@@ -698,14 +702,14 @@ command_test() {
     aix_ld_hack init
     execute $PYTHON_BIN -m pip install $PIP_ARGS safety==1.8.7
     execute $PYTHON_BIN -m safety check --full-report \
-        $SAFETY_FALSE_POSITIVES_OPTS $SAFETY_IGNORED_OPTS
-    if [ -n "$SAFETY_FALSE_POSITIVES_OPTS" ]; then
+        ${SAFETY_FALSE_POSITIVES_OPTS-} ${SAFETY_IGNORED_OPTS:-}
+    if [ -n "${SAFETY_FALSE_POSITIVES_OPTS-}" ]; then
         SAFETY_FALSE_POSITIVES_IDS="\
             $(echo $SAFETY_FALSE_POSITIVES_OPTS | sed s/\-i\ //g)"
         echo "Following Safety DB IDs were excepted as false positives:"
         echo "${SAFETY_FALSE_POSITIVES_IDS}"
     fi
-    if [ -n "$SAFETY_IGNORED_OPTS" ]; then
+    if [ -n "${SAFETY_IGNORED_OPTS-}" ]; then
         SAFETY_IGNORED_IDS="\
             $(echo $SAFETY_IGNORED_OPTS | sed s/\-i\ //g)"
         (>&2 echo "Following Safety DB IDs were excepted from checks:")
@@ -776,7 +780,7 @@ command_compat() {
     unset CHEVAH_CACHE CHEVAH_BUILD
     # Some tests might fail due to causes which are not related to python.
     execute ./brink.sh deps
-    if [ x"$CHEVAH_CONTAINER" = x"yes" ]; then
+    if [ "${CHEVAH_CONTAINER:-}" = "yes" ]; then
         execute ./brink.sh test_ci2
     else
         execute ./brink.sh test_ci

--- a/chevah_build
+++ b/chevah_build
@@ -322,7 +322,7 @@ if [ "${OS%sol*}" = "" ]; then
 elif [ "${OS%fbsd*}" = "" -o "${OS%obsd*}" = "" ]; then
     # Use PIC (Position Independent Code) on FreeBSD and OpenBSD with Clang.
     export CFLAGS="${CFLAGS:-} -fPIC"
-elif [ ${CC:-} = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
+elif [ "${CC:-}" = "gcc" -a ${ARCH%%64} != "$ARCH" ]; then
     # Use PIC (Position Independent Code) with GCC on 64-bit arches.
     export CFLAGS="${CFLAGS:-} -fPIC"
 fi
@@ -340,7 +340,7 @@ case "$ARCH" in
         let JOBS=CPUS
         ;;
 esac
-if [ -n "$MAKE" ]; then
+if [ -n "${MAKE-}" ]; then
     export MAKE="$MAKE -j${JOBS}"
 fi
 

--- a/chevah_build
+++ b/chevah_build
@@ -167,7 +167,7 @@ case $OS in
         export CXX="xlC_r"
         export MAKE="gmake"
         export PATH="/usr/vac/bin:$PATH"
-        export CFLAGS="$CFLAGS -O2 -D_LARGE_FILES=1"
+        export CFLAGS="${CFLAGS:-} -O2 -D_LARGE_FILES=1"
         # IBM's OpenSSL libs are mixed 32/64bit binaries in AIX, so we need to
         # be specific about what kind of build we want, because otherwise we
         # might get 64bit libraries.
@@ -207,6 +207,7 @@ case $OS in
         "
         add_ignored_safety_ids_for_cryptography32
         # On AIX 7.1, cryptography build fails with Let's Encrypt certificates.
+        # This is enough to fix it, no need to redefine PIP_ARGS as well.
         PYPI_SITE="http://bin.chevah.com:20080/pypi"
         ;;
     sol*)

--- a/chevah_build
+++ b/chevah_build
@@ -88,10 +88,6 @@ PIP_LIBRARIES_OPENSSL_102="\
     "
 
 PYPI_SITE="https://bin.chevah.com:20443/pypi"
-if [ "${OS%aix*}" = "" ]; then
-    # On AIX 7.1, there are issues with Let's Encrypt certificates.
-    PYPI_SITE="http://bin.chevah.com:20080/pypi"
-fi
 # Arguments that are sent when using pip.
 PIP_ARGS="\
     --index-url=${PYPI_SITE}/simple \
@@ -206,6 +202,8 @@ case $OS in
             python-modules/cryptography-3.2.1 \
         "
         add_ignored_safety_ids_for_cryptography32
+        # On AIX 7.1, cryptography build fails with Let's Encrypt certificates.
+        PYPI_SITE="http://bin.chevah.com:20080/pypi"
         ;;
     sol*)
         # Only Sun's Studio compiler is supported.

--- a/functions.sh
+++ b/functions.sh
@@ -10,7 +10,7 @@ OS=""
 INSTALL_FOLDER=""
 
 # Check if debugging environment variable is set and initialize with 0 if not.
-if [ -z "$DEBUG" ] ; then
+if [ -z "${DEBUG:-}" ] ; then
     DEBUG=0
 fi
 
@@ -18,10 +18,15 @@ fi
 help_text_help=\
 "Show help for a command."
 command_help() {
-    local command=$1
+    if [ -n "${1-}" ]; then
+        local command=$1
+    else
+        local command=""
+    fi
     local help_command="help_$command"
-    # Test to see if we have a valid help method, otherwise call
-    # the general help.
+    # Test to see if we have a valid help method,
+    # otherwise call the general help.
+    set +o errexit
     type $help_command &> /dev/null
     if [ $? -eq 0 ]; then
         $help_command
@@ -33,6 +38,7 @@ command_help() {
             echo -e "$command_name\t\t${!help_text}"
         done
     fi
+    set -o errexit
 }
 
 #
@@ -41,8 +47,12 @@ command_help() {
 # Select fuctions which are made public.
 #
 select_command() {
-    local command=$1
-    shift
+    if [ -n "${1-}" ]; then
+        local command=$1
+        shift
+    else
+        local command=""
+    fi
     case $command in
         "")
             command_help
@@ -52,6 +62,7 @@ select_command() {
             # Test to see if we have a valid command, otherwise call
             # the general help.
             call_command="command_$command"
+            set +o errexit
             type $call_command &> /dev/null
             if [ $? -eq 0 ]; then
                 $call_command $@
@@ -61,6 +72,7 @@ select_command() {
                 echo "Unknown command: ${command}."
                 exit 1
             fi
+            set -o errexit
         ;;
     esac
 }


### PR DESCRIPTION
Scope
=====

Fixes #154.
Fixes #155.


Changes
=======

Only use an HTTP PyPI server on AIX for `cryptography`'s deps. The previous check was wrong because it checked `$OS` before it was defined.

Use the `ld` hack when building Safety deps AIX, otherwise installing Cython as a dep for PyYAML fails on AIX, where it has to be built.

**Drive-by fix**:
  * Enabled basic Bash checks to avoid issues with empty env vars in the future.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.

Run the automated tests.