### PR TITLE
Ubuntu 22.04 support.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git curl bash gcc make m4 automake libtool patch zlib-dev libffi-dev ncurses-dev linux-headers musl-dev openssl-dev lddtree shadow sudo openssh-client paxctl
+        apk add git curl bash gcc make m4 automake libtool patch libffi-dev zlib-dev openssl-dev musl-dev lddtree shadow sudo openssh-client paxctl
 
     # Stick to CentOS 8.2 as OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         # CentOS 5.11 setup was saved as an image pushed to Docker Hub. See the
         # Overview section at https://hub.docker.com/r/proatria/centos for details.
-        container: [ 'alpine:3.14', 'centos:8.2.2004', 'proatria/centos:5.11-chevah1', 'ubuntu:22.04' ]
+        container: [ 'alpine:3.14', 'centos:8.2.2004', 'proatria/centos:5.11-chevah1' ]
     timeout-minutes: 30
     steps:
 
@@ -51,13 +51,6 @@ jobs:
         sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/8.2.2004/@ /etc/yum.repos.d/*.repo
         yum -y upgrade
         yum -y install git curl gcc make m4 automake libtool patch openssl-devel zlib-devel libffi-devel ncurses-devel sudo which openssh-clients
-
-    - name: Ubuntu setup
-      if: startsWith(matrix.container, 'ubuntu')
-      run: |
-        apt update
-        apt -y dist-upgrade
-        apt -y install git curl gcc make m4 automake libtool patch libffi-dev zlib1g-dev libncurses5-dev libssl-dev sudo openssh-client
 
     # On a Docker container, everything runs as root by default.
     - name: Chevah user setup

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         # CentOS 5.11 setup was saved as an image pushed to Docker Hub. See the
         # Overview section at https://hub.docker.com/r/proatria/centos for details.
-        container: [ 'alpine:3.14', 'centos:8.2.2004', 'proatria/centos:5.11-chevah1' ]
+        container: [ 'alpine:3.14', 'centos:8.2.2004', 'proatria/centos:5.11-chevah1', 'ubuntu:22.04' ]
     timeout-minutes: 30
     steps:
 
@@ -51,6 +51,13 @@ jobs:
         sed -i s@^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever/@baseurl=https://vault.centos.org/8.2.2004/@ /etc/yum.repos.d/*.repo
         yum -y upgrade
         yum -y install git curl gcc make m4 automake libtool patch openssl-devel zlib-devel libffi-devel ncurses-devel sudo which openssh-clients
+
+    - name: Ubuntu setup
+      if: startsWith(matrix.container, 'ubuntu')
+      run: |
+        apt update
+        apt -y dist-upgrade
+        apt -y install git curl gcc make m4 automake libtool patch libffi-dev zlib1g-dev libssl-dev sudo openssh-client
 
     # On a Docker container, everything runs as root by default.
     - name: Chevah user setup

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -57,7 +57,7 @@ jobs:
       run: |
         apt update
         apt -y dist-upgrade
-        apt -y install git curl gcc make m4 automake libtool patch libffi-dev zlib1g-dev libssl-dev sudo openssh-client
+        apt -y install git curl gcc make m4 automake libtool patch libffi-dev zlib1g-dev libncurses5-dev libssl-dev sudo openssh-client
 
     # On a Docker container, everything runs as root by default.
     - name: Chevah user setup

--- a/brink.sh
+++ b/brink.sh
@@ -729,6 +729,9 @@ detect_os() {
                         if [ ${os_version_chevah%%04} == ${os_version_chevah} \
                             -o $(( ${os_version_chevah:0:2} % 2 )) -ne 0 ]; then
                             check_linux_glibc
+                        elif [ ${os_version_chevah} == "2204" ]; then
+                            # OpenSSL 3.0.x not supported by cryptography 3.3.x.
+                            check_linux_glibc
                         fi
                         set_os_if_not_generic "ubuntu" $os_version_chevah
                         ;;

--- a/brink.sh
+++ b/brink.sh
@@ -315,8 +315,6 @@ pip_install() {
     rm -rf ${BUILD_FOLDER}/pip-build
     ${PYTHON_BIN} -m \
         pip install \
-            --trusted-host bin.chevah.com \
-            --trusted-host pypi-internal.chevah.com \
             --index-url=$PIP_INDEX_URL \
             --build=${BUILD_FOLDER}/pip-build \
             $1

--- a/chevah_build
+++ b/chevah_build
@@ -122,8 +122,8 @@ BUILD_FOLDER='build'
 # On platforms with a choice of C compilers, you may choose among the
 # available compilers by setting CC and CXX further down in this script.
 COMMON_PKGS="gcc make m4 automake libtool patch"
-DEB_PKGS="$COMMON_PKGS git zlib1g-dev libffi-dev libncurses5-dev libssl-dev"
-RPM_PKGS="$COMMON_PKGS git zlib-devel libffi-devel ncurses-devel openssl-devel"
+DEB_PKGS="$COMMON_PKGS git libffi-dev zlib1g-dev libncurses5-dev libssl-dev"
+RPM_PKGS="$COMMON_PKGS git libffi-devel zlib-devel ncurses-devel openssl-devel"
 APK_PKGS="$COMMON_PKGS git zlib-dev musl-dev openssl-dev linux-headers lddtree"
 # No automated Windows package management, but here's what it's needed.
 CHOCO_PKGS="vcpython27 make git StrawberryPerl nasm 7zip"

--- a/chevah_build
+++ b/chevah_build
@@ -490,11 +490,6 @@ command_build() {
         fi
         # On Windows, the BATs from pyca/infra do the install part.
         if [ "${OS%win*}" != "" ]; then
-            # Place SSL headers where they can be picked up.
-            echo "Copying OpenSSL $OPENSSL_VERSION headers..."
-            execute cp -r \
-                build/openssl-${OPENSSL_VERSION}/include/openssl \
-                ${INSTALL_FOLDER}/include/
             # To make sure they're found, we're back to using CPPFLAGS.
             export CPPFLAGS="${CPPFLAGS:-} -I${INSTALL_FOLDER}/include"
         fi

--- a/chevah_build
+++ b/chevah_build
@@ -342,7 +342,10 @@ case "$ARCH" in
         let JOBS=CPUS
         ;;
 esac
-export MAKE="${MAKE:-} -j${JOBS}"
+# Only add to $MAKE if there is one, so that NMAKE on Windows is not confused.
+if [ -n "${MAKE-}" ]; then
+    export MAKE="$MAKE -j${JOBS}"
+fi
 
 
 #

--- a/chevah_build
+++ b/chevah_build
@@ -97,7 +97,6 @@ PYPI_SITE="https://bin.chevah.com:20443/pypi"
 # Arguments that are sent when using pip.
 PIP_ARGS="\
     --index-url=${PYPI_SITE}/simple \
-    --trusted-host=bin.chevah.com \
     --no-cache-dir \
     --no-warn-script-location \
     "

--- a/chevah_build
+++ b/chevah_build
@@ -342,9 +342,7 @@ case "$ARCH" in
         let JOBS=CPUS
         ;;
 esac
-if [ -n "${MAKE-}" ]; then
-    export MAKE="$MAKE -j${JOBS}"
-fi
+export MAKE="${MAKE:-} -j${JOBS}"
 
 
 #
@@ -418,8 +416,9 @@ check_dependencies() {
     command -v makeinfo
     if [ $? -ne 0 ]; then
         (>&2 echo "Missing makeinfo, trying to link it to /bin/true in ~/bin.")
-        mkdir -p ~/bin
-        ln -s /bin/true ~/bin/makeinfo
+        execute mkdir -p ~/bin
+        execute rm -f ~/bin/makeinfo
+        execute ln -s /bin/true ~/bin/makeinfo
         export PATH=$PATH:~/bin/
     fi
 }
@@ -429,7 +428,7 @@ help_text_clean="Clean the build."
 command_clean() {
     if [ -e ${BUILD_FOLDER} ]; then
         echo 'Previous build sub-directory found. Removing...'
-        rm -rf ${BUILD_FOLDER}
+        execute rm -rf ${BUILD_FOLDER}
     fi
 }
 
@@ -730,13 +729,11 @@ command_test() {
             (>&2 echo -e "\tSkipping because of upstream issues.")
             ;;
         lnx*)
-            set +o nounset
-            if [ x"$CHEVAH_CONTAINER" = x"yes" ]; then
+            if [ x${CHEVAH_CONTAINER-} = x"yes" ]; then
                 (>&2 echo -e "\tSkipping as it fails under Docker on CentOS 5.")
             else
                 execute $PYTHON_BIN ${SCANDIR_FOLDER}/test/run_tests.py
             fi
-            set -o nounset
             ;;
         *)
             # UTF-8 locale is needed for the tests to pass on remaining OS'es.

--- a/chevah_build
+++ b/chevah_build
@@ -122,9 +122,9 @@ BUILD_FOLDER='build'
 # On platforms with a choice of C compilers, you may choose among the
 # available compilers by setting CC and CXX further down in this script.
 COMMON_PKGS="gcc make m4 automake libtool patch"
-DEB_PKGS="$COMMON_PKGS git libssl-dev zlib1g-dev libffi-dev libncurses5-dev"
-RHEL_PKGS="$COMMON_PKGS git openssl-devel zlib-devel libffi-devel ncurses-devel"
-ALP_PKGS="$COMMON_PKGS git zlib-dev linux-headers musl-dev openssl-dev lddtree"
+DEB_PKGS="$COMMON_PKGS git zlib1g-dev libffi-dev libncurses5-dev libssl-dev"
+RPM_PKGS="$COMMON_PKGS git zlib-devel libffi-devel ncurses-devel openssl-devel"
+APK_PKGS="$COMMON_PKGS git zlib-dev musl-dev openssl-dev linux-headers lddtree"
 # No automated Windows package management, but here's what it's needed.
 CHOCO_PKGS="vcpython27 make git StrawberryPerl nasm 7zip"
 
@@ -363,12 +363,12 @@ check_dependencies() {
             check_command="dpkg --status"
             ;;
         rhel*|amzn*)
-            packages=$RHEL_PKGS
+            packages=$RPM_PKGS
             check_command="rpm --query"
             ;;
         alpine*)
             # Alpine 3.9 switched back to OpenSSL as default.
-            packages=$ALP_PKGS
+            packages=$APK_PKGS
             check_command="apk info -q -e"
             ;;
         # On remaining OS'es we just check for some of the needed commands.
@@ -383,7 +383,7 @@ check_dependencies() {
             packages="git gmake patch xlc_r seq sudo"
             ;;
         macos)
-            packages="$CC make m4 libtool git patch"
+            packages="$CC make m4 libtool git patch perl"
             ;;
         win)
             # To not get confused by MSYS2's perl, we check for wperl.

--- a/external_deps.csv
+++ b/external_deps.csv
@@ -1,36 +1,37 @@
 OS,AIX,,,Amazon,Alpine,,Debian,FreeBSD,,HP-UX,macOS,OS X,RHEL,,,,SLES,,Solaris,,,,Ubuntu,,,,Windows,
-OS Version,5.3³,6.1³,7.1¹,2¹,3.12³,3.14¹,5.0+²,11.4³,12.2+³,11.31³,10.13+¹,10.8³,5.11¹,6.x¹,7.x¹,8.x¹,11SP4²,12SP3²,10u8+³,11.0/11.1³,11.2³,11.4³,14.04¹,16.04¹,18.04¹,20.04¹,"XP, 2003, 2008³","2012r2, 2016, 2019¹"
+OS Version,5.3³,6.1³,7.1¹,2¹,3.12³,3.14¹,5.0+²,11.4³,12.2+³,11.31³,10.13+¹,10.8³,5.11¹,6.x¹,7.x¹,8.x¹,11SP4²,12SP3²,10u8+³,11.0/11.1³,11.2³,11.4³,14.04¹,16.04¹,18.04¹,20.04¹,"XP, 2003, 2008³","2012r2, 2016, 2019, 2022¹"
 OpenSSL⁶,"1.0.2v-chevah2 (statically linked with stdlib “ssl”)
-1.0.2v-chevah2 (statically linked with cryptography)",1.0.2k (from AIX Web Download Pack Programs),"1.0.2v-chevah3 (statically linked with stdlib “ssl”)
-1.0.2v-chevah3 (statically linked with cryptography)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)",1.1.1j,1.1.1m,"1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)",1.0.1u,1.0.2s,1.0.2h,"1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)","1.1.1g (statically built for stdlib “ssl”)
-1.1.1g (bundled with upstream cryptography 2.9.1)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)",1.1.1c FIPS,"1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)",1.0.2n (from upstream Oracle patches),1.0.0x,1.0.1h,"
-1.0.2o","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)","1.1.1m (statically linked with stdlib “ssl”)
-1.1.1m (statically linked with cryptography)",1.1.0g,1.1.1f,"1.0.2t (bundled with upstream Python 2.7.18)
+1.0.2v-chevah2 (statically linked with cryptography)",1.0.2k (from AIX Web Download Pack Programs),"1.0.2v-chevah4 (statically linked with stdlib “ssl”)
+1.0.2v-chevah4 (statically linked with cryptography)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)",1.1.1j,1.1.1m,"1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)",1.0.1u,1.0.2s,1.0.2h,"1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1g (statically built for stdlib “ssl”)
+1.1.1g (bundled with upstream cryptography 2.9.1)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1cFIPS /
+1.1.1k FIPS","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)",1.0.2n (from upstream Oracle patches),1.0.0x,1.0.1h,"
+1.0.2o","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)","1.1.1n (statically linked with stdlib “ssl”)
+1.1.1n (statically linked with cryptography)",1.1.0g,1.1.1f,"1.0.2t (bundled with upstream Python 2.7.18)
 1.1.1g (bundled with upstream cryptography 2.9.1)","1.0.2t⁹ (bundled with upstream Python 2.7.18)
-1.1.1m (built from upstream sources for cryptography)"
+1.1.1n (built from upstream sources for cryptography)"
 Python,2.7.18+patches,2.7.18¹¹,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18¹¹,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18¹¹,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.8⁴,2.7.18¹¹,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18+patches,2.7.18¹¹,2.7.18¹³
 SQLite,3.34.1,3.34.1,3.37.2,3.37.2,3.34.1,3.37.2,3.37.2,3.30.1,3.34.1,3.34.1,3.37.2,3.30.1,3.37.2,3.37.2,3.37.2,3.37.2,3.37.2,3.37.2,3.34.1,3.30.1,3.34.1,3.34.1,3.37.2,3.37.2,3.37.2,3.37.2,3.30.1 (we overwrite version from upstream Python at build time),3.37.2 (we overwrite version from upstream Python at build time)
 Expat,2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.1.0⁵ (bundled with Python 2.7.8),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python),2.2.8 (bundled with Python)
-zlib,1.2.11,p/o,1.2.11,1.2.11,p/o,p/o,1.2.11,p/o,p/o,1.2.11,p/o,p/o,1.2.11,1.2.11,p/o,p/o,1.2.11,p/o,p/o,p/o,p/o,p/o,1.2.11,1.2.11,p/o,p/o,1.2.11 (bundled with Python),1.2.11 (bundled with Python)
+zlib,1.2.12,p/o,1.2.12,1.2.12,p/o,p/o,1.2.12,p/o,p/o,1.2.12,p/o,p/o,1.2.12,1.2.12,p/o,p/o,1.2.12,p/o,p/o,p/o,p/o,p/o,1.2.12,1.2.12,p/o,p/o,1.2.11⁸ (bundled with Python),1.2.11⁸ (bundled with Python)
 bzip2,1.0.8,1.0.8,1.0.8,1.0.8,1.0.8,1.0.8,1.0.8,p/o,p/o,1.0.8,p/o,p/o,1.0.8,1.0.8,1.0.8,1.0.8,1.0.8,1.0.8,p/o,p/o,p/o,p/o,1.0.8,1.0.8,1.0.8,1.0.8,1.0.6 (bundled with Python),1.0.6 (bundled with Python)
-libffi,3.2.1,3.2.1,3.2.1,p/o,p/o,3.2.1,3.2.1,3.2.1,3.2.1,3.2.1,p/o,p/o,3.2.1,3.2.1,p/o,p/o,3.2.1,3.2.1,n/a,n/a,3.2.1,3.2.1,p/o,p/o,p/o,p/o,n/a,n/a
+libffi,3.4.2,3.4.2,3.4.2,p/o,p/o,3.4.2,3.4.2,3.4.2,3.4.2,3.4.2,p/o,p/o,3.4.2,3.4.2,p/o,p/o,3.4.2,3.4.2,n/a,n/a,3.4.2,3.4.2,p/o,p/o,p/o,p/o,n/a,n/a
 libedit,n/a,n/a,n/a,n/a,20170329-3.1,20170329-3.1,n/a,20170329-3.1,20170329-3.1,n/a,20170329-3.1,20170329-3.1,n/a,n/a,n/a,20170329-3.1,n/a,20170329-3.1,n/a,20170329-3.1,20170329-3.1,20170329-3.1,n/a,n/a,20170329-3.1,20170329-3.1,n/a,n/a
 pysqlite,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,2.8.3,"n/a, upstream sqlite3 is used","n/a, upstream sqlite3 is used"
-pip,20.3.4,9.0.3,20.3.4,20.3.4,9.0.3,20.3.4,20.3.4,9.0.3,20.3.4,20.3.4,20.3.4,9.0.3,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,9.0.3,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4,20.3.4
+pip,20.3.4¹⁴,9.0.3¹⁴,20.3.4chevah1,20.3.4chevah1,9.0.3¹⁴,20.3.4chevah1,20.3.4chevah1,9.0.3¹⁴,20.3.4chevah1,20.3.4¹⁴,20.3.4chevah1,9.0.3¹⁴,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4¹⁴,9.0.3¹⁴,20.3.4¹⁴,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4chevah1,20.3.4¹⁴,20.3.4chevah1
 setuptools,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,41.6.0,41.6.0,41.6.0,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1,44.1.1
 wheel,0.36.2,0.33.6,0.37.0,0.37.0,0.33.6,0.37.0,0.37.0,0.33.6,0.37.0,0.36.2,0.37.0,0.33.6,0.37.0,0.37.0,0.37.0,0.37.0,0.37.0,0.37.0,0.36.2,0.33.6,0.36.2,0.37.0,0.37.0,0.37.0,0.37.0,0.37.0,0.36.2,0.37.0
 pycparser,2.20,2.20,2.21,2.21,2.21,2.21,2.21,2.20,2.21,2.20,2.21,2.20,2.21,2.21,2.21,2.21,2.21,2.21,2.20,2.20,2.20,2.21,2.21,2.21,2.21,2.21,2.20,2.21
 setproctitle,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10,1.1.10
-cryptography,3.2.1¹²,2.9.2¹²,3.2.1¹²,3.3.2,3.3.2,3.3.2,3.3.2,2.9.2¹²,3.3.2,n/a,3.3.2,2.9.2¹² (wheel includes OpenSSL),3.3.2,3.3.2,3.3.2,3.3.2,3.3.2,3.3.2,n/a,n/a,n/a,3.2.1¹²,3.3.2,3.3.2,3.3.2,3.3.2,2.9.2¹² (wheel includes OpenSSL),3.3.2 (wheel includes OpenSSL)
+cryptography,3.2.1¹²,2.9.2¹²,3.2.1¹²,3.3.2,3.3.2,3.3.2,3.3.2,2.9.2¹²,3.3.2,n/a,3.3.2,2.9.2¹² (wheel includes OpenSSL),3.3.2,3.3.2,3.3.2,3.3.2,3.3.2,3.3.2,n/a,n/a,n/a,3.2.1¹²,3.3.2,3.3.2,3.3.2,3.3.2,2.9.2¹² (wheel includes OpenSSL),3.3.2
 six,1.15.0,1.13.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.11.0,1.15.0,1.15.0,1.15.0,1.11.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.11.0,1.15.0,1.15.0,1.11.0,1.11.0,1.11.0,1.11.0,1.11.0,1.11.0
 ipaddress,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,n/a,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,n/a,n/a,n/a,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23,1.0.23
 cffi,1.14.5,1.14.0,1.15.0,1.15.0,1.14.0,1.15.0,1.15.0,1.14.0,1.15.0,n/a,1.15.0,1.14.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,n/a,1.14.0,1.14.5,1.15.0,1.15.0,1.15.0,1.15.0,1.15.0,1.14.0,1.15.0
@@ -44,7 +45,7 @@ subprocess32,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3.5.4,3
 bcrypt,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,n/a,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7,3.1.7
 pywin32,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,,n/a,227,228
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Abbreviations:,n/a: not applicable,,,,,,,,,,,Notes:,"0. Dependencies above are listed as per the current build process, not for the latest released versions.",,,,,,,,,,,,,,,
+Abbreviations:,n/a: not applicable,,,,,,,,,,,Notes:,"0. Dependencies above are listed as per the current build process, not necessarily for the latest released versions of python-package.",,,,,,,,,,,,,,,
 ,p/o: provided with OS,,,,,,,,,,,,"1. Tier 1 platforms, fully supported and tested",,,,,,,,,,,,,,,
 Colour codes:,DARKGREY: Tier 2 platforms and their problematic dependencies,,,,,,,,,,,,"2. Tier 2 platforms, partially supported, still built",,,,,,,,,,,,,,,
 ,LIGHT GREY: Tier 3 platforms and their problematic dependencies,,,,,,,,,,,,"3. Tier 3 platforms, supported at some point, not built any more",,,,,,,,,,,,,,,
@@ -52,9 +53,10 @@ Colour codes:,DARKGREY: Tier 2 platforms and their problematic dependencies,,,,,
 ,"BLUE: possible vulnerabilities found upstream, but no released version has them yet",,,,,,,,,,,,5. https://github.com/libexpat/libexpat/blob/master/expat/Changes,,,,,,,,,,,,,,,
 ,ORANGE: minor vulnerabilities found,,,,,,,,,,,,"6. Unless specified otherwise, OpenSSL libs are linked against dynamically",,,,,,,,,,,,,,,
 ,RED: major vulnerabilities found,,,,,,,,,,,,"7. pyOpenSSL 0.14 and newer is a major rewrite, so it's not clear to what extent their vulnerabilities do apply",,,,,,,,,,,,,,,
-,MAGENTA: vulnerability status could not be established,,,,,,,,,,,,8. n/a,,,,,,,,,,,,,,,
+,MAGENTA: vulnerability status could not be established,,,,,,,,,,,,8. https://cve.report/CVE-2018-25032,,,,,,,,,,,,,,,
 ,DEFAULT COLOUR: maintained upstream or not applicable,,,,,,,,,,,,9. https://www.openssl.org/news/openssl-1.0.2-notes.html,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,10. https://www.openssl.org/news/openssl-1.1.1-notes.html,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,11. https://github.com/ActiveState/cpython/tags,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,12. https://cryptography.io/en/latest/changelog.html,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,"13. On Windows, the upstream Python 2.7.18 packages are hot patched with all the ActivePython fixes except CVE-2021-3177",,,,,,,,,,,,,,,
+,,,,,,,,,,,,,14. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3572,,,,,,,,,,,,,,,

--- a/external_deps.fods
+++ b/external_deps.fods
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:generator>LibreOffice/7.3.1.1$Linux_X86_64 LibreOffice_project/30$Build-1</meta:generator><meta:editing-cycles>113</meta:editing-cycles><meta:editing-duration>PT6H52M13S</meta:editing-duration><dc:title>python-package - external dependencies and associated vulnerabilities</dc:title><dc:date>2022-02-21T13:14:13.809875521</dc:date><meta:document-statistic meta:table-count="1" meta:cell-count="850" meta:object-count="0"/></office:meta>
+ <office:meta><meta:generator>LibreOffice/7.3.3.2$Linux_X86_64 LibreOffice_project/30$Build-2</meta:generator><meta:editing-cycles>122</meta:editing-cycles><meta:editing-duration>PT7H25M55S</meta:editing-duration><dc:title>python-package - external dependencies and associated vulnerabilities</dc:title><dc:date>2022-05-04T12:52:45.185120579</dc:date><meta:document-statistic meta:table-count="1" meta:cell-count="851" meta:object-count="0"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaLeft" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaWidth" config:type="int">48122</config:config-item>
-   <config:config-item config:name="VisibleAreaHeight" config:type="int">22096</config:config-item>
+   <config:config-item config:name="VisibleAreaHeight" config:type="int">22583</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
-       <config:config-item config:name="CursorPositionX" config:type="int">10</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">2</config:config-item>
+       <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">31</config:config-item>
        <config:config-item config:name="HorizontalSplitMode" config:type="short">2</config:config-item>
        <config:config-item config:name="VerticalSplitMode" config:type="short">2</config:config-item>
        <config:config-item config:name="HorizontalSplitPosition" config:type="int">1</config:config-item>
        <config:config-item config:name="VerticalSplitPosition" config:type="int">1</config:config-item>
-       <config:config-item config:name="ActiveSplitRange" config:type="short">3</config:config-item>
+       <config:config-item config:name="ActiveSplitRange" config:type="short">2</config:config-item>
        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">1</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
@@ -95,7 +95,7 @@
    <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
    <config:config-item config:name="PrinterName" config:type="string">Generic Printer</config:config-item>
    <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrinterSetup" config:type="base64Binary">oAH+/0dlbmVyaWMgUHJpbnRlcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU0dFTlBSVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAMAwQAAAAAAAAAEAAhSAAAEdAAASm9iRGF0YSAxCnByaW50ZXI9R2VuZXJpYyBQcmludGVyCm9yaWVudGF0aW9uPVBvcnRyYWl0CmNvcGllcz0xCmNvbGxhdGU9ZmFsc2UKbWFyZ2luYWRqdXN0bWVudD0wLDAsMCwwCmNvbG9yZGVwdGg9MjQKcHNsZXZlbD0wCnBkZmRldmljZT0xCmNvbG9yZGV2aWNlPTAKUFBEQ29udGV4dERhdGEKUGFnZVNpemU6QTQARHVwbGV4Ok5vbmUAABIAQ09NUEFUX0RVUExFWF9NT0RFDwBEdXBsZXhNb2RlOjpPZmY=</config:config-item>
+   <config:config-item config:name="PrinterSetup" config:type="base64Binary">oAH+/0dlbmVyaWMgUHJpbnRlcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU0dFTlBSVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAMAwQAAAAAAAAAEAAhSAAAEdAAASm9iRGF0YSAxCnByaW50ZXI9R2VuZXJpYyBQcmludGVyCm9yaWVudGF0aW9uPVBvcnRyYWl0CmNvcGllcz0xCmNvbGxhdGU9ZmFsc2UKbWFyZ2luYWRqdXN0bWVudD0wLDAsMCwwCmNvbG9yZGVwdGg9MjQKcHNsZXZlbD0wCnBkZmRldmljZT0xCmNvbG9yZGV2aWNlPTAKUFBEQ29udGV4dERhdGEKRHVwbGV4Ok5vbmUAUGFnZVNpemU6QTQAABIAQ09NUEFUX0RVUExFWF9NT0RFDwBEdXBsZXhNb2RlOjpPZmY=</config:config-item>
    <config:config-item config:name="RasterIsVisible" config:type="boolean">false</config:config-item>
    <config:config-item config:name="RasterResolutionX" config:type="int">1000</config:config-item>
    <config:config-item config:name="RasterResolutionY" config:type="int">1000</config:config-item>
@@ -124,7 +124,7 @@
   </office:script>
  </office:scripts>
  <office:font-face-decls>
-  <style:font-face style:name="Archivo" svg:font-family="Archivo" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Archivo Light" svg:font-family="&apos;Archivo Light&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
   <style:font-face style:name="Arial" svg:font-family="Arial"/>
   <style:font-face style:name="Arimo" svg:font-family="Arimo" style:font-family-generic="swiss" style:font-pitch="variable"/>
   <style:font-face style:name="Cambria" svg:font-family="Cambria"/>
@@ -151,75 +151,90 @@
    <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
    <style:map style:condition="value()&gt;=0" style:apply-style-name="N112P0"/>
   </number:currency-style>
-  <number:number-style style:name="N116">
-   <number:scientific-number number:decimal-places="1" number:min-decimal-places="1" number:min-integer-digits="1" number:min-exponent-digits="1" number:exponent-interval="3" number:forced-exponent-sign="true"/>
-  </number:number-style>
-  <number:time-style style:name="N115">
+  <number:time-style style:name="N116" number:title="User-defined">
    <number:minutes number:style="long"/>
    <number:text>:</number:text>
-   <number:seconds number:style="long" number:decimal-places="1"/>
+   <number:seconds number:style="long"/>
   </number:time-style>
-  <number:time-style style:name="N114" number:truncate-on-overflow="false">
+  <number:time-style style:name="N115" number:truncate-on-overflow="false">
    <number:hours/>
    <number:text>:</number:text>
    <number:minutes number:style="long"/>
    <number:text>:</number:text>
    <number:seconds number:style="long"/>
   </number:time-style>
-  <number:time-style style:name="N113" number:title="User-defined">
+  <number:time-style style:name="N114">
    <number:minutes number:style="long"/>
    <number:text>:</number:text>
-   <number:seconds number:style="long"/>
+   <number:seconds number:style="long" number:decimal-places="1"/>
   </number:time-style>
-  <number:number-style style:name="N10135P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>     </number:text>
+  <number:number-style style:name="N113">
+   <number:scientific-number number:decimal-places="1" number:min-decimal-places="1" number:min-integer-digits="1" number:min-exponent-digits="1" number:exponent-interval="3" number:forced-exponent-sign="true"/>
   </number:number-style>
-  <number:number-style style:name="N10135" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10139P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+  </number:number-style>
+  <number:number-style style:name="N10139" number:language="ro" number:country="RO">
    <style:text-properties fo:color="#ff0000"/>
    <number:text>-</number:text>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>     </number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10135P0"/>
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10139P0"/>
   </number:number-style>
-  <number:number-style style:name="N10134P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:fill-character> </number:fill-character>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>      </number:text>
-  </number:number-style>
-  <number:number-style style:name="N10134P1" style:volatile="true" number:language="ro" number:country="RO">
-   <number:text>-</number:text>
-   <number:fill-character> </number:fill-character>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>      </number:text>
-  </number:number-style>
-  <number:number-style style:name="N10134P2" style:volatile="true" number:language="ro" number:country="RO">
-   <number:fill-character> </number:fill-character>
-   <number:text>-</number:text>
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="0"/>
-   <number:text>      </number:text>
-  </number:number-style>
-  <number:text-style style:name="N10134" number:language="ro" number:country="RO">
-   <number:text-content/>
-   <number:text> </number:text>
-   <style:map style:condition="value()&gt;0" style:apply-style-name="N10134P0"/>
-   <style:map style:condition="value()&lt;0" style:apply-style-name="N10134P1"/>
-   <style:map style:condition="value()=0" style:apply-style-name="N10134P2"/>
-  </number:text-style>
-  <number:number-style style:name="N10130P0" style:volatile="true" number:language="ro" number:country="RO">
+  <number:date-style style:name="N10136" number:language="ro" number:country="RO">
+   <number:day number:style="long"/>
+   <number:text>.</number:text>
+   <number:month number:textual="true"/>
+  </number:date-style>
+  <number:number-style style:name="N10135P0" style:volatile="true" number:language="ro" number:country="RO">
    <number:fill-character> </number:fill-character>
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
    <number:text> lei </number:text>
+  </number:number-style>
+  <number:number-style style:name="N10135P1" style:volatile="true" number:language="ro" number:country="RO">
+   <number:text>-</number:text>
+   <number:fill-character> </number:fill-character>
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei </number:text>
+  </number:number-style>
+  <number:number-style style:name="N10135P2" style:volatile="true" number:language="ro" number:country="RO">
+   <number:fill-character> </number:fill-character>
+   <number:text>- lei </number:text>
+  </number:number-style>
+  <number:text-style style:name="N10135" number:language="ro" number:country="RO">
+   <number:text-content/>
+   <number:text> </number:text>
+   <style:map style:condition="value()&gt;0" style:apply-style-name="N10135P0"/>
+   <style:map style:condition="value()&lt;0" style:apply-style-name="N10135P1"/>
+   <style:map style:condition="value()=0" style:apply-style-name="N10135P2"/>
+  </number:text-style>
+  <number:number-style style:name="N10131P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>     </number:text>
+  </number:number-style>
+  <number:number-style style:name="N10131" number:language="ro" number:country="RO">
+   <number:text>-</number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>     </number:text>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10131P0"/>
+  </number:number-style>
+  <number:number-style style:name="N10130P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:fill-character> </number:fill-character>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>      </number:text>
   </number:number-style>
   <number:number-style style:name="N10130P1" style:volatile="true" number:language="ro" number:country="RO">
    <number:text>-</number:text>
    <number:fill-character> </number:fill-character>
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei </number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>      </number:text>
   </number:number-style>
   <number:number-style style:name="N10130P2" style:volatile="true" number:language="ro" number:country="RO">
    <number:fill-character> </number:fill-character>
-   <number:text>- lei </number:text>
+   <number:text>-</number:text>
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="0"/>
+   <number:text>      </number:text>
   </number:number-style>
   <number:text-style style:name="N10130" number:language="ro" number:country="RO">
    <number:text-content/>
@@ -251,106 +266,41 @@
    <style:map style:condition="value()=0" style:apply-style-name="N10126P2"/>
   </number:text-style>
   <number:number-style style:name="N10122P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>     </number:text>
   </number:number-style>
   <number:number-style style:name="N10122" number:language="ro" number:country="RO">
+   <style:text-properties fo:color="#ff0000"/>
    <number:text>-</number:text>
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text>     </number:text>
    <style:map style:condition="value()&gt;=0" style:apply-style-name="N10122P0"/>
   </number:number-style>
-  <number:number-style style:name="N10121P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-  </number:number-style>
-  <number:number-style style:name="N10121" number:language="ro" number:country="RO">
-   <style:text-properties fo:color="#ff0000"/>
-   <number:text>-</number:text>
-   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10121P0"/>
-  </number:number-style>
-  <number:number-style style:name="N10119P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>     </number:text>
-  </number:number-style>
-  <number:number-style style:name="N10119" number:language="ro" number:country="RO">
-   <number:text>-</number:text>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text>     </number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10119P0"/>
-  </number:number-style>
-  <number:number-style style:name="N10117P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-  </number:number-style>
-  <number:number-style style:name="N10117" number:language="ro" number:country="RO">
-   <number:text>-</number:text>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10117P0"/>
-  </number:number-style>
-  <number:number-style style:name="N10116P0" style:volatile="true" number:language="ro" number:country="RO">
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-  </number:number-style>
-  <number:number-style style:name="N10116" number:language="ro" number:country="RO">
-   <style:text-properties fo:color="#ff0000"/>
-   <number:text>-</number:text>
-   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
-   <number:text> lei</number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10116P0"/>
-  </number:number-style>
-  <number:date-style style:name="N10114" number:language="ro" number:country="RO">
-   <number:day number:style="long"/>
-   <number:text>.</number:text>
-   <number:month number:textual="true"/>
-   <number:text>.</number:text>
-   <number:year/>
-  </number:date-style>
-  <number:date-style style:name="N10113" number:language="ro" number:country="RO">
-   <number:day number:style="long"/>
-   <number:text>.</number:text>
-   <number:month number:textual="true"/>
-  </number:date-style>
-  <number:date-style style:name="N10112" number:language="ro" number:country="RO">
-   <number:month number:textual="true"/>
-   <number:text>.</number:text>
-   <number:year/>
-  </number:date-style>
-  <number:time-style style:name="N10111" number:language="ro" number:country="RO">
-   <number:hours/>
-   <number:text>:</number:text>
-   <number:minutes number:style="long"/>
-   <number:text> </number:text>
-   <number:am-pm/>
-  </number:time-style>
-  <number:number-style style:name="N10139P0" style:volatile="true" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10120P0" style:volatile="true" number:language="ro" number:country="RO">
    <number:fill-character> </number:fill-character>
    <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
    <number:text> lei </number:text>
   </number:number-style>
-  <number:number-style style:name="N10139P1" style:volatile="true" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10120P1" style:volatile="true" number:language="ro" number:country="RO">
    <number:text>-</number:text>
    <number:fill-character> </number:fill-character>
    <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
    <number:text> lei </number:text>
   </number:number-style>
-  <number:number-style style:name="N10139P2" style:volatile="true" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10120P2" style:volatile="true" number:language="ro" number:country="RO">
    <number:fill-character> </number:fill-character>
    <number:text>-</number:text>
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="0"/>
    <number:text> lei </number:text>
   </number:number-style>
-  <number:text-style style:name="N10139" number:language="ro" number:country="RO">
+  <number:text-style style:name="N10120" number:language="ro" number:country="RO">
    <number:text-content/>
    <number:text> </number:text>
-   <style:map style:condition="value()&gt;0" style:apply-style-name="N10139P0"/>
-   <style:map style:condition="value()&lt;0" style:apply-style-name="N10139P1"/>
-   <style:map style:condition="value()=0" style:apply-style-name="N10139P2"/>
+   <style:map style:condition="value()&gt;0" style:apply-style-name="N10120P0"/>
+   <style:map style:condition="value()&lt;0" style:apply-style-name="N10120P1"/>
+   <style:map style:condition="value()=0" style:apply-style-name="N10120P2"/>
   </number:text-style>
-  <number:time-style style:name="N10110" number:language="ro" number:country="RO">
+  <number:time-style style:name="N10116" number:language="ro" number:country="RO">
    <number:hours/>
    <number:text>:</number:text>
    <number:minutes number:style="long"/>
@@ -359,25 +309,75 @@
    <number:text> </number:text>
    <number:am-pm/>
   </number:time-style>
-  <number:number-style style:name="N10109P0" style:volatile="true" number:language="ro" number:country="RO">
+  <number:time-style style:name="N10115" number:language="ro" number:country="RO">
+   <number:hours/>
+   <number:text>:</number:text>
+   <number:minutes number:style="long"/>
+   <number:text> </number:text>
+   <number:am-pm/>
+  </number:time-style>
+  <number:number-style style:name="N10114P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+  </number:number-style>
+  <number:number-style style:name="N10114" number:language="ro" number:country="RO">
+   <number:text>-</number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10114P0"/>
+  </number:number-style>
+  <number:number-style style:name="N10113P0" style:volatile="true" number:language="ro" number:country="RO">
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
    <number:text>     </number:text>
   </number:number-style>
-  <number:number-style style:name="N10109" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10113" number:language="ro" number:country="RO">
    <number:text>-</number:text>
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
    <number:text>     </number:text>
-   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10109P0"/>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10113P0"/>
   </number:number-style>
-  <number:number-style style:name="N10108P0" style:volatile="true" number:language="ro" number:country="RO">
+  <number:date-style style:name="N10112" number:language="ro" number:country="RO">
+   <number:month number:textual="true"/>
+   <number:text>.</number:text>
+   <number:year/>
+  </number:date-style>
+  <number:number-style style:name="N10111P0" style:volatile="true" number:language="ro" number:country="RO">
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
    <number:text>     </number:text>
   </number:number-style>
-  <number:number-style style:name="N10108" number:language="ro" number:country="RO">
+  <number:number-style style:name="N10111" number:language="ro" number:country="RO">
    <style:text-properties fo:color="#ff0000"/>
    <number:text>-</number:text>
    <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
    <number:text>     </number:text>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10111P0"/>
+  </number:number-style>
+  <number:number-style style:name="N10138P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+  </number:number-style>
+  <number:number-style style:name="N10138" number:language="ro" number:country="RO">
+   <number:text>-</number:text>
+   <number:number number:decimal-places="0" number:min-decimal-places="0" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+   <style:map style:condition="value()&gt;=0" style:apply-style-name="N10138P0"/>
+  </number:number-style>
+  <number:date-style style:name="N10109" number:language="ro" number:country="RO">
+   <number:day number:style="long"/>
+   <number:text>.</number:text>
+   <number:month number:textual="true"/>
+   <number:text>.</number:text>
+   <number:year/>
+  </number:date-style>
+  <number:number-style style:name="N10108P0" style:volatile="true" number:language="ro" number:country="RO">
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
+  </number:number-style>
+  <number:number-style style:name="N10108" number:language="ro" number:country="RO">
+   <style:text-properties fo:color="#ff0000"/>
+   <number:text>-</number:text>
+   <number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1" number:grouping="true"/>
+   <number:text> lei</number:text>
    <style:map style:condition="value()&gt;=0" style:apply-style-name="N10108P0"/>
   </number:number-style>
   <style:style style:name="Default" style:family="table-cell">
@@ -793,6 +793,11 @@
    <style:paragraph-properties fo:text-align="start" css3t:text-justify="auto" fo:margin-left="0cm" style:writing-mode="page"/>
    <style:text-properties fo:color="#6aa84f" style:text-outline="false" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Sans" fo:font-size="11pt" fo:language="en" fo:country="US" fo:font-style="normal" fo:text-shadow="none" style:text-underline-style="none" fo:font-weight="bold" style:text-underline-mode="continuous" style:text-overline-mode="continuous" style:text-line-through-mode="continuous" style:font-name-asian="Liberation Sans" style:font-size-asian="11pt" style:language-asian="zh" style:country-asian="CN" style:font-style-asian="normal" style:font-weight-asian="bold" style:font-name-complex="Arial" style:font-size-complex="11pt" style:language-complex="hi" style:country-complex="IN" style:font-style-complex="normal" style:font-weight-complex="bold" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
   </style:style>
+  <style:style style:name="ce117" style:family="table-cell" style:parent-style-name="Default">
+   <style:table-cell-properties fo:border-bottom="none" style:text-align-source="value-type" style:repeat-content="false" fo:wrap-option="no-wrap" fo:border-left="0.74pt solid #000000" style:direction="ltr" fo:border-right="none" style:rotation-angle="0" style:rotation-align="none" style:shrink-to-fit="false" fo:border-top="none" style:vertical-align="bottom" loext:vertical-justify="auto"/>
+   <style:paragraph-properties css3t:text-justify="auto" fo:margin-left="0cm" style:writing-mode="page"/>
+   <style:text-properties style:use-window-font-color="true" style:text-outline="false" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Sans" fo:font-size="11pt" fo:font-style="normal" fo:text-shadow="none" style:text-underline-style="none" fo:font-weight="bold" style:font-name-asian="Liberation Sans" style:font-size-asian="11pt" style:font-style-asian="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="normal" style:font-weight-complex="bold"/>
+  </style:style>
   <style:style style:name="ce118" style:family="table-cell" style:parent-style-name="Default">
    <style:table-cell-properties fo:border-bottom="none" style:text-align-source="value-type" style:repeat-content="false" fo:wrap-option="no-wrap" fo:border-left="0.74pt solid #000000" style:direction="ltr" fo:border-right="none" style:rotation-angle="0" style:rotation-align="none" style:shrink-to-fit="false" fo:border-top="none" style:vertical-align="bottom" loext:vertical-justify="auto"/>
    <style:paragraph-properties css3t:text-justify="auto" fo:margin-left="0cm" style:writing-mode="page"/>
@@ -808,7 +813,7 @@
    <style:paragraph-properties fo:text-align="start" css3t:text-justify="auto" fo:margin-left="0cm" style:writing-mode="page"/>
    <style:text-properties fo:color="#cccccc" style:text-outline="false" style:text-line-through-style="none" style:text-line-through-type="none" style:font-name="Sans" fo:font-size="11pt" fo:font-style="normal" fo:text-shadow="none" style:text-underline-style="none" fo:font-weight="bold" style:font-size-asian="11pt" style:font-style-asian="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-style-complex="normal" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="ce123" style:family="table-cell" style:parent-style-name="Default">
+  <style:style style:name="ce127" style:family="table-cell" style:parent-style-name="Default">
    <style:table-cell-properties fo:border="0.74pt solid #000000"/>
    <style:text-properties style:font-name="Sans"/>
   </style:style>
@@ -1029,10 +1034,10 @@
    </style:footer-style>
   </style:page-layout>
   <style:style style:name="T1" style:family="text">
-   <style:text-properties style:font-name-complex="Arial" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" style:text-position="0% 100%" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name="Sans" fo:color="#ff9900"/>
+   <style:text-properties fo:color="#ff9900" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
   </style:style>
   <style:style style:name="T2" style:family="text">
-   <style:text-properties style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:text-position="0% 100%" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-weight-complex="normal" style:font-weight-asian="normal" fo:font-weight="normal" style:font-name="Cambria" fo:color="#000000"/>
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000" style:font-name="Cambria" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
   <style:style style:name="T3" style:family="text">
    <style:text-properties fo:color="#cccccc" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
@@ -1041,211 +1046,160 @@
    <style:text-properties fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Sans"/>
   </style:style>
   <style:style style:name="T5" style:family="text">
-   <style:text-properties style:font-weight-asian="normal" fo:font-weight="normal" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:font-weight-complex="normal" fo:color="#d9d9d9" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T6" style:family="text">
-   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:font-name-asian="Liberation Sans" style:font-weight-complex="bold" style:font-weight-asian="bold" fo:font-weight="bold" fo:color="#cccccc"/>
-  </style:style>
-  <style:style style:name="T7" style:family="text">
-   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:font-name-asian="Liberation Sans" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T8" style:family="text">
-   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T9" style:family="text">
-   <style:text-properties fo:font-style="normal" style:text-line-through-mode="continuous" style:text-line-through-type="none" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-size-complex="11pt" fo:language="en" fo:country="US" style:font-name-asian="Liberation Sans" style:font-weight-asian="normal" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:font-weight-complex="normal" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" fo:text-shadow="none" fo:font-weight="normal" style:font-name-complex="Arial" style:font-name="Sans" style:font-size-asian="11pt" style:font-style-asian="normal" fo:font-size="11pt" fo:color="#d9d9d9" style:font-relief="none" style:text-underline-style="none" style:text-underline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T10" style:family="text">
-   <style:text-properties fo:font-style="normal" style:text-line-through-mode="continuous" style:text-line-through-type="none" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-size-complex="11pt" fo:language="en" fo:country="US" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" fo:text-shadow="none" style:font-name-complex="Arial" style:font-name="Sans" style:font-size-asian="11pt" style:font-style-asian="normal" fo:font-size="11pt" style:font-relief="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:color="#cccccc" style:font-weight-asian="bold" fo:font-weight="bold" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="T11" style:family="text">
-   <style:text-properties fo:font-style="normal" style:text-line-through-mode="continuous" style:text-line-through-type="none" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-size-complex="11pt" fo:language="en" fo:country="US" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" fo:text-shadow="none" style:font-name-complex="Arial" style:font-name="Sans" style:font-size-asian="11pt" style:font-style-asian="normal" fo:font-size="11pt" style:font-relief="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-weight-complex="normal" fo:font-weight="normal" style:font-weight-asian="normal"/>
-  </style:style>
-  <style:style style:name="T12" style:family="text">
-   <style:text-properties fo:font-style="normal" style:text-line-through-mode="continuous" style:text-line-through-type="none" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-size-complex="11pt" fo:language="en" fo:country="US" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" fo:text-shadow="none" style:font-name-complex="Arial" style:font-name="Sans" style:font-size-asian="11pt" style:font-style-asian="normal" fo:font-size="11pt" style:font-relief="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-weight-complex="normal" fo:font-weight="normal" style:font-weight-asian="normal" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T13" style:family="text">
-   <style:text-properties fo:color="#6aa84f" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T14" style:family="text">
-   <style:text-properties fo:color="#cccccc" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T15" style:family="text">
-   <style:text-properties style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
-  </style:style>
-  <style:style style:name="T16" style:family="text">
-   <style:text-properties fo:color="#999999" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T17" style:family="text">
-   <style:text-properties fo:color="#cccccc" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T18" style:family="text">
-   <style:text-properties fo:color="#4a86e8" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T19" style:family="text">
-   <style:text-properties fo:color="#ff9900" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T20" style:family="text">
-   <style:text-properties fo:color="#ff0000" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T21" style:family="text">
-   <style:text-properties fo:color="#ff00ff" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T22" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="normal" style:font-style-complex="normal" style:font-weight-complex="normal" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:font-relief="none" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" fo:color="#d9d9d9" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:text-emphasize="none" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T23" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:font-style-complex="normal" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:font-relief="none" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:text-emphasize="none" style:font-name-asian="Liberation Sans" style:font-weight-complex="bold" style:font-weight-asian="bold" fo:font-weight="bold" fo:color="#cccccc"/>
-  </style:style>
-  <style:style style:name="T24" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:font-style-complex="normal" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:font-relief="none" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:text-emphasize="none" style:font-name-asian="Liberation Sans" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T25" style:family="text">
-   <style:text-properties fo:color="#cccccc" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="T26" style:family="text">
-   <style:text-properties fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T27" style:family="text">
-   <style:text-properties fo:color="#6aa84f" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T28" style:family="text">
-   <style:text-properties style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T29" style:family="text">
-   <style:text-properties fo:color="#ff9900" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T30" style:family="text">
-   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold" fo:color="#6aa84f"/>
-  </style:style>
-  <style:style style:name="T31" style:family="text">
-   <style:text-properties style:text-emphasize="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" style:font-style-asian="normal" style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:font-name="Cambria" style:font-name-asian="Liberation Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-position="0% 100%" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" fo:color="#999999" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-relief="none"/>
-  </style:style>
-  <style:style style:name="T32" style:family="text">
-   <style:text-properties style:text-emphasize="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-style-complex="normal" style:font-style-asian="normal" style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:language-asian="zh" style:country-asian="CN" style:text-outline="false" style:font-relief="none" style:font-name="Sans"/>
-  </style:style>
-  <style:style style:name="T33" style:family="text">
-   <style:text-properties fo:font-weight="bold" style:font-weight-complex="bold" style:font-name-asian="Liberation Sans" fo:color="#6aa84f" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-weight-asian="bold"/>
-  </style:style>
-  <style:style style:name="T34" style:family="text">
-   <style:text-properties style:font-name-asian="Liberation Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-weight-complex="normal" style:font-weight-asian="normal" fo:font-weight="normal"/>
-  </style:style>
-  <style:style style:name="T35" style:family="text">
-   <style:text-properties style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T36" style:family="text">
-   <style:text-properties style:font-weight-complex="bold" style:font-style-complex="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" fo:text-shadow="none" style:text-position="0% 100%" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name="Cambria" style:font-name-asian="Liberation Sans" fo:color="#cccccc" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-complex="Arial" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:text-outline="false" style:font-style-asian="normal"/>
-  </style:style>
-  <style:style style:name="T37" style:family="text">
-   <style:text-properties style:font-weight-complex="bold" style:font-style-complex="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" fo:text-shadow="none" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name-asian="Liberation Sans" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-complex="Arial" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:text-outline="false" style:font-style-asian="normal" style:font-name="Sans"/>
-  </style:style>
-  <style:style style:name="T38" style:family="text">
-   <style:text-properties fo:color="#999999" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T39" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T40" style:family="text">
-   <style:text-properties style:language-asian="zh" style:country-asian="CN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" style:text-position="0% 100%" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" fo:color="#d9d9d9" style:font-weight-asian="normal" fo:font-weight="normal" style:font-name-asian="Liberation Sans" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T41" style:family="text">
-   <style:text-properties style:language-asian="zh" style:country-asian="CN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" style:text-position="0% 100%" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-weight-asian="normal" fo:font-weight="normal" style:font-name-asian="Liberation Sans" style:font-weight-complex="normal" style:use-window-font-color="true"/>
-  </style:style>
-  <style:style style:name="T42" style:family="text">
-   <style:text-properties style:language-asian="zh" style:country-asian="CN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" style:text-position="0% 100%" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-weight-asian="normal" fo:font-weight="normal" style:font-weight-complex="normal" style:use-window-font-color="true" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T43" style:family="text">
-   <style:text-properties style:font-style-complex="normal" style:text-position="0% 100%" style:font-style-asian="normal" fo:color="#d9d9d9" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-weight-complex="normal" fo:language="en" fo:country="US" style:text-line-through-type="none" fo:font-weight="normal" fo:font-size="11pt" style:font-name="Sans" style:text-line-through-mode="continuous" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:language-asian="zh" style:country-asian="CN" fo:font-style="normal" fo:text-shadow="none" style:text-outline="false"/>
-  </style:style>
-  <style:style style:name="T44" style:family="text">
-   <style:text-properties style:font-style-complex="normal" style:text-position="0% 100%" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-weight-complex="normal" fo:language="en" fo:country="US" style:text-line-through-type="none" fo:font-weight="normal" fo:font-size="11pt" style:font-name="Sans" style:text-line-through-mode="continuous" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:language-asian="zh" style:country-asian="CN" fo:font-style="normal" fo:text-shadow="none" style:text-outline="false" style:use-window-font-color="true"/>
-  </style:style>
-  <style:style style:name="T45" style:family="text">
-   <style:text-properties style:font-style-complex="normal" style:text-position="0% 100%" style:font-style-asian="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:language-complex="hi" style:country-complex="IN" style:text-emphasize="none" style:text-underline-style="none" style:text-underline-color="font-color" style:font-weight-complex="normal" fo:language="en" fo:country="US" style:text-line-through-type="none" fo:font-weight="normal" fo:font-size="11pt" style:font-name="Sans" style:text-line-through-mode="continuous" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:language-asian="zh" style:country-asian="CN" fo:font-style="normal" fo:text-shadow="none" style:text-outline="false" style:use-window-font-color="true" style:font-name-asian="Liberation Sans"/>
-  </style:style>
-  <style:style style:name="T46" style:family="text">
-   <style:text-properties fo:color="#cccccc" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T47" style:family="text">
-   <style:text-properties style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
-  </style:style>
-  <style:style style:name="T48" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Cambria" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T49" style:family="text">
-   <style:text-properties fo:color="#000000"/>
-  </style:style>
-  <style:style style:name="T50" style:family="text">
-   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
-  </style:style>
-  <style:style style:name="T51" style:family="text">
-   <style:text-properties style:font-weight-complex="bold" style:font-style-complex="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" fo:text-shadow="none" style:text-position="0% 100%" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name="Cambria" style:font-name-asian="Liberation Sans" fo:color="#999999" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-complex="Arial" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:text-outline="false" style:font-style-asian="normal"/>
-  </style:style>
-  <style:style style:name="T52" style:family="text">
-   <style:text-properties fo:color="#cccccc" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T53" style:family="text">
-   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000"/>
-  </style:style>
-  <style:style style:name="T54" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:font-style-complex="normal" style:font-name="Sans" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:font-relief="none" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:text-emphasize="none" style:font-name-asian="Liberation Sans" style:font-weight-asian="normal" fo:font-weight="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T55" style:family="text">
-   <style:text-properties fo:color="#cccccc"/>
-  </style:style>
-  <style:style style:name="T56" style:family="text">
-   <style:text-properties fo:color="#000000" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal"/>
-  </style:style>
-  <style:style style:name="T57" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T58" style:family="text">
-   <style:text-properties fo:color="#999999" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T59" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T60" style:family="text">
    <style:text-properties fo:color="#d9d9d9" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
   </style:style>
-  <style:style style:name="T61" style:family="text">
-   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#d9d9d9" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:font-name="Sans"/>
+  <style:style style:name="T6" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#cccccc" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="T62" style:family="text">
-   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:font-name="Sans" fo:color="#cccccc" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  <style:style style:name="T7" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="T63" style:family="text">
-   <style:text-properties style:text-line-through-mode="continuous" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:font-style-asian="normal" style:font-weight-complex="normal" style:font-weight-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:font-style-complex="normal" fo:language="en" fo:country="US" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="normal" fo:font-size="11pt" style:font-name="Sans" fo:color="#d9d9d9" fo:text-shadow="none" style:text-emphasize="none"/>
+  <style:style style:name="T8" style:family="text">
+   <style:text-properties fo:color="#6aa84f" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T64" style:family="text">
-   <style:text-properties style:text-line-through-mode="continuous" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:font-style-complex="normal" fo:language="en" fo:country="US" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-name="Sans" fo:text-shadow="none" style:text-emphasize="none" fo:color="#cccccc" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  <style:style style:name="T9" style:family="text">
+   <style:text-properties fo:font-weight="bold" style:font-weight-complex="bold" fo:color="#cccccc" style:language-complex="hi" style:country-complex="IN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:font-weight-asian="bold"/>
   </style:style>
-  <style:style style:name="T65" style:family="text">
-   <style:text-properties style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#93c47d"/>
+  <style:style style:name="T10" style:family="text">
+   <style:text-properties style:language-complex="hi" style:country-complex="IN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" fo:font-weight="normal" fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
-  <style:style style:name="T66" style:family="text">
-   <style:text-properties fo:color="#cccccc" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  <style:style style:name="T11" style:family="text">
+   <style:text-properties fo:color="#cccccc" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
   </style:style>
-  <style:style style:name="T67" style:family="text">
-   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
+  <style:style style:name="T12" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
   </style:style>
-  <style:style style:name="T68" style:family="text">
-   <style:text-properties style:language-complex="hi" style:country-complex="IN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" fo:color="#ff9900" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name="Sans"/>
+  <style:style style:name="T13" style:family="text">
+   <style:text-properties fo:color="#999999" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
   </style:style>
-  <style:style style:name="T69" style:family="text">
+  <style:style style:name="T14" style:family="text">
+   <style:text-properties fo:color="#cccccc" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T15" style:family="text">
+   <style:text-properties fo:color="#4a86e8" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T16" style:family="text">
+   <style:text-properties fo:color="#ff9900" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T17" style:family="text">
+   <style:text-properties fo:color="#ff0000" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T18" style:family="text">
+   <style:text-properties fo:color="#ff00ff" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T19" style:family="text">
+   <style:text-properties fo:color="#cccccc" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T20" style:family="text">
+   <style:text-properties fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T21" style:family="text">
+   <style:text-properties style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-name="Sans" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" fo:color="#cccccc" fo:font-weight="bold"/>
+  </style:style>
+  <style:style style:name="T22" style:family="text">
+   <style:text-properties style:font-relief="none" style:text-emphasize="none" style:font-style-complex="normal" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:text-line-through-mode="continuous" fo:text-shadow="none" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-name="Sans" style:text-overline-style="none" style:text-overline-color="font-color" style:language-complex="hi" style:country-complex="IN" fo:font-weight="normal" fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T23" style:family="text">
+   <style:text-properties fo:color="#6aa84f" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T24" style:family="text">
+   <style:text-properties fo:color="#ff9900" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T25" style:family="text">
    <style:text-properties fo:color="#6aa84f" fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
-  <style:style style:name="T70" style:family="text">
+  <style:style style:name="T26" style:family="text">
+   <style:text-properties style:text-line-through-mode="continuous" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:font-style-asian="normal" style:font-weight-complex="bold" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:font-style-complex="normal" fo:language="en" fo:country="US" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" style:font-name="Sans" fo:color="#cccccc" fo:text-shadow="none" style:text-emphasize="none"/>
+  </style:style>
+  <style:style style:name="T27" style:family="text">
+   <style:text-properties style:text-line-through-mode="continuous" style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:font-style-asian="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" style:font-name-complex="Arial" style:font-name-asian="Liberation Sans" style:language-complex="hi" style:country-complex="IN" style:language-asian="zh" style:country-asian="CN" style:font-style-complex="normal" fo:language="en" fo:country="US" style:text-outline="false" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:font-name="Sans" fo:text-shadow="none" style:text-emphasize="none" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T28" style:family="text">
+   <style:text-properties fo:color="#999999" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T29" style:family="text">
+   <style:text-properties fo:font-weight="bold" style:font-weight-complex="bold" style:font-name-asian="Liberation Sans" fo:color="#6aa84f" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-weight-asian="bold"/>
+  </style:style>
+  <style:style style:name="T30" style:family="text">
+   <style:text-properties style:font-name-asian="Liberation Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name="Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-weight-complex="normal" style:font-weight-asian="normal" fo:font-weight="normal"/>
+  </style:style>
+  <style:style style:name="T31" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T32" style:family="text">
+   <style:text-properties fo:color="#999999" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T33" style:family="text">
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T34" style:family="text">
+   <style:text-properties fo:color="#d9d9d9" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T35" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:use-window-font-color="true"/>
+  </style:style>
+  <style:style style:name="T36" style:family="text">
+   <style:text-properties fo:color="#cccccc" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T37" style:family="text">
+   <style:text-properties style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
+  </style:style>
+  <style:style style:name="T38" style:family="text">
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Cambria" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T39" style:family="text">
+   <style:text-properties fo:color="#000000"/>
+  </style:style>
+  <style:style style:name="T40" style:family="text">
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T41" style:family="text">
+   <style:text-properties fo:color="#cccccc" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T42" style:family="text">
+   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000"/>
+  </style:style>
+  <style:style style:name="T43" style:family="text">
+   <style:text-properties fo:color="#cccccc"/>
+  </style:style>
+  <style:style style:name="T44" style:family="text">
+   <style:text-properties fo:color="#000000" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T45" style:family="text">
+   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T46" style:family="text">
+   <style:text-properties style:font-weight-complex="bold" style:font-style-complex="normal" style:font-weight-asian="bold" style:font-size-complex="11pt" style:font-size-asian="11pt" fo:text-shadow="none" style:text-position="0% 100%" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-weight="bold" fo:font-size="11pt" fo:color="#cccccc" style:language-complex="hi" style:country-complex="IN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Cambria" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:text-emphasize="none" style:font-relief="none" style:text-outline="false" style:font-style-asian="normal"/>
+  </style:style>
+  <style:style style:name="T47" style:family="text">
+   <style:text-properties style:font-style-complex="normal" style:font-size-complex="11pt" style:font-size-asian="11pt" fo:text-shadow="none" style:text-position="0% 100%" fo:font-style="normal" style:text-line-through-type="none" style:text-underline-style="none" style:text-underline-color="font-color" fo:font-size="11pt" style:language-complex="hi" style:country-complex="IN" style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Cambria" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:text-emphasize="none" style:font-relief="none" style:text-outline="false" style:font-style-asian="normal" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T48" style:family="text">
+   <style:text-properties style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" fo:color="#93c47d"/>
+  </style:style>
+  <style:style style:name="T49" style:family="text">
+   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-line-through-mode="continuous" style:text-position="0% 100%" fo:color="#cccccc" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none"/>
+  </style:style>
+  <style:style style:name="T50" style:family="text">
+   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-relief="none" style:text-line-through-mode="continuous" style:text-position="0% 100%" style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:language-asian="zh" style:country-asian="CN" fo:language="en" fo:country="US" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T51" style:family="text">
+   <style:text-properties fo:color="#cccccc" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T52" style:family="text">
+   <style:text-properties fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000"/>
+  </style:style>
+  <style:style style:name="T53" style:family="text">
+   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#ff9900" style:font-name="Sans" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:font-relief="none" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:text-position="0% 100%" style:language-asian="zh" style:country-asian="CN"/>
+  </style:style>
+  <style:style style:name="T54" style:family="text">
+   <style:text-properties style:text-overline-style="none" style:text-overline-color="font-color" style:font-name="Sans" fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:font-relief="none" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:text-position="0% 100%" style:language-asian="zh" style:country-asian="CN" fo:color="#000000" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
+  </style:style>
+  <style:style style:name="T55" style:family="text">
    <style:text-properties fo:color="#6aa84f" style:font-name="Cambria" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-position="0% 100%" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
   </style:style>
-  <style:style style:name="T71" style:family="text">
+  <style:style style:name="T56" style:family="text">
    <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" style:use-window-font-color="true" style:font-name="Sans" fo:font-weight="normal" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
-  </style:style>
-  <style:style style:name="T72" style:family="text">
-   <style:text-properties fo:color="#6aa84f" fo:font-size="11pt" fo:font-weight="bold" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-weight-asian="bold" style:font-weight-complex="bold" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
-  </style:style>
-  <style:style style:name="T73" style:family="text">
-   <style:text-properties fo:font-size="11pt" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="en" fo:country="US" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN" style:font-name-asian="Liberation Sans" style:font-name-complex="Arial" style:font-size-asian="11pt" style:font-size-complex="11pt" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color" fo:color="#000000" fo:font-weight="normal" style:text-position="0% 100%" style:font-weight-asian="normal" style:font-weight-complex="normal"/>
   </style:style>
  </office:automatic-styles>
  <office:master-styles>
@@ -1267,7 +1221,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2022-02-21">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="12:14:52.459610191">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2022-05-04">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="12:25:56.955146480">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -1344,7 +1298,7 @@
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="2" table:number-rows-spanned="1">
       <text:p>FreeBSD</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:style-name="ce123"/>
+     <table:covered-table-cell table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string">
       <text:p>HP-UX</text:p>
      </table:table-cell>
@@ -1358,25 +1312,25 @@
       <text:p>RHEL</text:p>
      </table:table-cell>
      <table:covered-table-cell table:style-name="ce1"/>
-     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce123"/>
+     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="2" table:number-rows-spanned="1">
       <text:p>SLES</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:style-name="ce123"/>
+     <table:covered-table-cell table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="4" table:number-rows-spanned="1">
       <text:p>Solaris</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:number-columns-repeated="3" table:style-name="ce123"/>
+     <table:covered-table-cell table:number-columns-repeated="3" table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="4" table:number-rows-spanned="1">
       <text:p>Ubuntu</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:number-columns-repeated="3" table:style-name="ce123"/>
+     <table:covered-table-cell table:number-columns-repeated="3" table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="2" table:number-rows-spanned="1">
       <text:p>Windows</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:style-name="ce123"/>
+     <table:covered-table-cell table:style-name="ce127"/>
      <table:table-cell table:style-name="ce1" table:number-columns-repeated="15"/>
-     <table:table-cell table:style-name="ce123" table:number-columns-repeated="17"/>
+     <table:table-cell table:style-name="ce127" table:number-columns-repeated="17"/>
      <table:table-cell/>
     </table:table-row>
     <table:table-row table:style-name="ro2">
@@ -1385,7 +1339,7 @@
      </table:table-cell>
      <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">5.3</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">6.1</text:span>³</text:p>
+     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">6.1</text:span>³</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string">
       <text:p>7.1¹</text:p>
@@ -1393,18 +1347,18 @@
      <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
       <text:p>2¹</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">3.12</text:span>³</text:p>
+     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">3.12</text:span>³</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce90" office:value-type="string" calcext:value-type="string">
       <text:p>3.14¹</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T31">5.0+</text:span><text:span text:style-name="T32">²</text:span></text:p>
+     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T28">5.0+</text:span><text:span text:style-name="T4">²</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">11.4</text:span>³</text:p>
+     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">11.4</text:span>³</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">12.2+</text:span><text:span text:style-name="T37">³</text:span></text:p>
+     <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">12.2+</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce96" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">11.31</text:span><text:span text:style-name="T37">³</text:span></text:p>
+     <table:table-cell table:style-name="ce96" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">11.31</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string">
       <text:p>10.13+¹</text:p>
@@ -1423,17 +1377,17 @@
      <table:table-cell table:style-name="ce90" office:value-type="string" calcext:value-type="string">
       <text:p>8.x¹</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T51">11SP4</text:span><text:span text:style-name="T37">²</text:span></text:p>
+     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T28">11SP4</text:span><text:span text:style-name="T4">²</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce90" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T51">12SP3</text:span><text:span text:style-name="T37">²</text:span></text:p>
+     <table:table-cell table:style-name="ce90" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T28">12SP3</text:span><text:span text:style-name="T4">²</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce172" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T52">10u8+</text:span><text:span text:style-name="T53">³</text:span></text:p>
+     <table:table-cell table:style-name="ce172" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T41">10u8+</text:span><text:span text:style-name="T42">³</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">11.0/11.1</text:span>³</text:p>
+     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">11.0/11.1</text:span>³</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">11.2</text:span><text:span text:style-name="T37">³</text:span></text:p>
+     <table:table-cell table:style-name="ce68" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">11.2</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">11.4</text:span><text:span text:style-name="T37">³</text:span></text:p>
+     <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">11.4</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce126" office:value-type="string" calcext:value-type="string">
       <text:p>14.04¹</text:p>
@@ -1447,10 +1401,10 @@
      <table:table-cell table:style-name="ce74" office:value-type="string" calcext:value-type="string">
       <text:p>20.04¹</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">XP, 2003, 2008</text:span><text:span text:style-name="T37">³</text:span></text:p>
+     <table:table-cell table:style-name="ce92" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T3">XP, 2003, 2008</text:span><text:span text:style-name="T4">³</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce112" office:value-type="string" calcext:value-type="string">
-      <text:p>2012r2, 2016, 2019¹</text:p>
+      <text:p>2012r2, 2016, 2019, 2022¹</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce4" table:number-columns-repeated="15"/>
      <table:table-cell table:number-columns-repeated="18"/>
@@ -1458,13 +1412,13 @@
     <table:table-row table:style-name="ro3">
      <table:table-cell table:style-name="ce36" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T1">OpenSSL</text:span><text:span text:style-name="T2">⁶</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T5">1.0.2v-chevah2</text:span><text:span text:style-name="T6"> </text:span><text:span text:style-name="T7">(</text:span><text:span text:style-name="T8">statically linked with stdlib “ssl”</text:span><text:span text:style-name="T8">)</text:span></text:p><text:p><text:span text:style-name="T9">1.0.2v-chevah2</text:span><text:span text:style-name="T10"> </text:span><text:span text:style-name="T11">(</text:span><text:span text:style-name="T12">statically linked with cryptography</text:span><text:span text:style-name="T12">)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T5">1.0.2v-chevah2</text:span><text:span text:style-name="T6"> </text:span><text:span text:style-name="T7">(statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T5">1.0.2v-chevah2</text:span><text:span text:style-name="T6"> </text:span><text:span text:style-name="T7">(statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T22">1.0.2k</text:span><text:span text:style-name="T23"> </text:span><text:span text:style-name="T24">(from AIX Web Download Pack Programs)</text:span></text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T5">1.0.2k</text:span><text:span text:style-name="T6"> </text:span><text:span text:style-name="T7">(from AIX Web Download Pack Programs)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T27">1.0.2v-chevah3</text:span><text:span text:style-name="T28"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T27">1.0.2v-chevah3</text:span><text:span text:style-name="T28"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T23">1.0.2v-chevah4</text:span><text:span text:style-name="T7"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T23">1.0.2v-chevah4</text:span><text:span text:style-name="T7"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce58" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T30">1.1.1m</text:span> (statically linked with stdlib “ssl”)</text:p><text:p><text:span text:style-name="T30">1.1.1m</text:span> (statically linked with cryptography)</text:p>
+     <table:table-cell table:style-name="ce58" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T25">1.1.1n</text:span> (statically linked with stdlib “ssl”)</text:p><text:p><text:span text:style-name="T25">1.1.1n</text:span> (statically linked with cryptography)</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>1.1.1j</text:p>
@@ -1472,7 +1426,7 @@
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
       <text:p>1.1.1m</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce117" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce118" office:value-type="string" calcext:value-type="string">
       <text:p>1.0.1u</text:p>
@@ -1483,24 +1437,23 @@
      <table:table-cell table:style-name="ce130" office:value-type="string" calcext:value-type="string">
       <text:p>1.0.2h</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce155" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T40">1.1.1g</text:span><text:span text:style-name="T41"> </text:span><text:span text:style-name="T42">(statically built for stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T43">1.1.1g</text:span><text:span text:style-name="T44"> </text:span><text:span text:style-name="T45">(bundled with upstream cryptography 2.9.1)</text:span></text:p>
+     <table:table-cell table:style-name="ce155" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T34">1.1.1g</text:span><text:span text:style-name="T35"> (statically built for stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T34">1.1.1g</text:span><text:span text:style-name="T35"> (bundled with upstream cryptography 2.9.1)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce139" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce139" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce139" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce139" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>1.1.1c FIPS</text:p>
+     <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T23">1.1.1cFIPS /</text:span></text:p><text:p><text:span text:style-name="T23">1.1.1k FIPS</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce141" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce141" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T22">1.0.2n</text:span><text:span text:style-name="T23"> </text:span><text:span text:style-name="T54">(from upstream Oracle patches)</text:span></text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T5">1.0.2n</text:span><text:span text:style-name="T6"> </text:span><text:span text:style-name="T7">(from upstream Oracle patches)</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce109" office:value-type="string" calcext:value-type="string">
       <text:p>1.0.0x</text:p>
@@ -1508,11 +1461,11 @@
      <table:table-cell table:style-name="ce109" office:value-type="string" calcext:value-type="string">
       <text:p>1.0.1h</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p/><text:p><text:span text:style-name="T60">1.0.2o</text:span></text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p/><text:p><text:span text:style-name="T5">1.0.2o</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce8" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce135" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T33">1.1.1m</text:span><text:span text:style-name="T34"> (statically linked with cryptography)</text:span></text:p>
+     <table:table-cell table:style-name="ce135" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with stdlib “ssl”)</text:span></text:p><text:p><text:span text:style-name="T29">1.1.1n</text:span><text:span text:style-name="T30"> (statically linked with cryptography)</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string">
       <text:p>1.1.0g</text:p>
@@ -1520,9 +1473,9 @@
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
       <text:p>1.1.1f</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T61">1.0.2t</text:span><text:span text:style-name="T62"> </text:span>(bundled with upstream Python 2.7.18)</text:p><text:p><text:span text:style-name="T63">1.1.1g</text:span><text:span text:style-name="T64"> </text:span>(bundled with upstream cryptography 2.9.1)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T5">1.0.2t</text:span><text:span text:style-name="T6"> </text:span>(bundled with upstream Python 2.7.18)</text:p><text:p><text:span text:style-name="T5">1.1.1g</text:span><text:span text:style-name="T6"> </text:span>(bundled with upstream cryptography 2.9.1)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce141" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T68">1.0.2t</text:span>⁹ (bundled with upstream Python 2.7.18)</text:p><text:p><text:span text:style-name="T69">1.1.1m</text:span> (built from upstream sources for cryptography)</text:p>
+     <table:table-cell table:style-name="ce141" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T24">1.0.2t</text:span>⁹ (bundled with upstream Python 2.7.18)</text:p><text:p><text:span text:style-name="T25">1.1.1n</text:span> (built from upstream sources for cryptography)</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -1533,7 +1486,7 @@
      <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce29" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T25">2.7.18</text:span><text:span text:style-name="T26">¹¹</text:span></text:p>
+     <table:table-cell table:style-name="ce29" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T19">2.7.18</text:span><text:span text:style-name="T20">¹¹</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
@@ -1547,7 +1500,7 @@
      <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce122" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.7.18</text:span><text:span text:style-name="T35">¹¹</text:span></text:p>
+     <table:table-cell table:style-name="ce122" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.7.18</text:span><text:span text:style-name="T31">¹¹</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
@@ -1555,7 +1508,7 @@
      <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce148" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.7.18</text:span><text:span text:style-name="T35">¹¹</text:span></text:p>
+     <table:table-cell table:style-name="ce148" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.7.18</text:span><text:span text:style-name="T31">¹¹</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
@@ -1572,9 +1525,9 @@
      <table:table-cell table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce101" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T55">2.7.8</text:span><text:span text:style-name="T56">⁴</text:span></text:p>
+     <table:table-cell table:style-name="ce101" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T43">2.7.8</text:span><text:span text:style-name="T44">⁴</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce28" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.7.18</text:span><text:span text:style-name="T35">¹¹</text:span></text:p>
+     <table:table-cell table:style-name="ce28" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.7.18</text:span><text:span text:style-name="T31">¹¹</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce51" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
@@ -1591,9 +1544,9 @@
      <table:table-cell table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>2.7.18+patches</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce122" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.7.18</text:span><text:span text:style-name="T35">¹¹</text:span></text:p>
+     <table:table-cell table:style-name="ce122" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.7.18</text:span><text:span text:style-name="T31">¹¹</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce187" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">2.7.18</text:span><text:span text:style-name="T35">¹³</text:span></text:p>
+     <table:table-cell table:style-name="ce187" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T24">2.7.18</text:span><text:span text:style-name="T31">¹³</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -1658,9 +1611,9 @@
      <table:table-cell table:number-columns-repeated="3" table:style-name="ce52" office:value-type="string" calcext:value-type="string">
       <text:p>3.37.2</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">3.30.1</text:span><text:span text:style-name="T65"> </text:span>(we overwrite version from upstream Python at build time)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">3.30.1</text:span><text:span text:style-name="T48"> </text:span>(we overwrite version from upstream Python at build time)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T69">3.37.2</text:span> (we overwrite version from upstream Python at build time)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T25">3.37.2</text:span> (we overwrite version from upstream Python at build time)</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -1668,79 +1621,79 @@
      <table:table-cell table:style-name="ce36" office:value-type="string" calcext:value-type="string">
       <text:p>Expat</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">2.1.0</text:span>⁵ (bundled with Python 2.7.8)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.1.0</text:span>⁵ (bundled with Python 2.7.8)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">2.2.8</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">2.2.8</text:span> (bundled with Python)</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
     <table:table-row table:style-name="ro2">
-     <table:table-cell table:style-name="ce36" office:value-type="string" calcext:value-type="string">
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>zlib</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce37" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1749,7 +1702,7 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1758,7 +1711,7 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce83" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1767,10 +1720,10 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce52" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1779,7 +1732,7 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1794,10 +1747,10 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce23" office:value-type="string" calcext:value-type="string">
-      <text:p>1.2.11</text:p>
+      <text:p>1.2.12</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1805,9 +1758,9 @@
      <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">1.2.11</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T49">1.2.11</text:span><text:span text:style-name="T50">⁸</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">1.2.11</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce75" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T53">1.2.11</text:span><text:span text:style-name="T54">⁸</text:span> (bundled with Python)</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -1887,9 +1840,9 @@
      <table:table-cell table:style-name="ce37" office:value-type="string" calcext:value-type="string">
       <text:p>1.0.8</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">1.0.6</text:span> (bundled with Python)</text:p>
+     <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">1.0.6</text:span> (bundled with Python)</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce37" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T70">1.0.6</text:span><text:span text:style-name="T71"> (bundled with Python)</text:span></text:p>
+     <table:table-cell table:style-name="ce37" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T55">1.0.6</text:span><text:span text:style-name="T56"> (bundled with Python)</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -1898,13 +1851,13 @@
       <text:p>libffi</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce81" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1913,19 +1866,19 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce88" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce91" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce84" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1934,10 +1887,10 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce88" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce53" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce50" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -1946,10 +1899,10 @@
       <text:p>p/o</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce88" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce91" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>n/a</text:p>
@@ -1958,10 +1911,10 @@
       <text:p>n/a</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce94" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce91" office:value-type="string" calcext:value-type="string">
-      <text:p>3.2.1</text:p>
+      <text:p>3.4.2</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce60" office:value-type="string" calcext:value-type="string">
       <text:p>p/o</text:p>
@@ -2143,83 +2096,73 @@
      <table:table-cell table:style-name="ce36" office:value-type="string" calcext:value-type="string">
       <text:p>pip</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T9">20.3.4</text:span><text:span text:style-name="T10">¹⁴</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string">
-      <text:p>9.0.3</text:p>
+     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T21">9.0.3</text:span><text:span text:style-name="T22">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce83" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>9.0.3</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>9.0.3</text:p>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">9.0.3</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce83" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">9.0.3</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>9.0.3</text:p>
+      <text:p>20.3.4chevah1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce83" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">20.3.4</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">9.0.3</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce52" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">20.3.4</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string">
-      <text:p>9.0.3</text:p>
+     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">9.0.3</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+     <table:table-cell table:style-name="ce70" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">20.3.4</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce70" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+     <table:table-cell table:style-name="ce62" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T26">20.3.4</text:span><text:span text:style-name="T27">¹⁴</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce77" office:value-type="string" calcext:value-type="string">
-      <text:p>20.3.4</text:p>
+      <text:p>20.3.4chevah1</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -2527,11 +2470,11 @@
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>cryptography</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce19" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">3.2.1</text:span><text:span text:style-name="T15">¹²</text:span></text:p>
+     <table:table-cell table:style-name="ce19" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">3.2.1</text:span><text:span text:style-name="T12">¹²</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce38" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.9.2</text:span><text:span text:style-name="T15">¹²</text:span></text:p>
+     <table:table-cell table:style-name="ce38" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.9.2</text:span><text:span text:style-name="T12">¹²</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce133" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T29">3.2.1</text:span><text:span text:style-name="T15">¹²</text:span></text:p>
+     <table:table-cell table:style-name="ce133" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T24">3.2.1</text:span><text:span text:style-name="T12">¹²</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce100" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
@@ -2542,7 +2485,7 @@
      <table:table-cell table:style-name="ce100" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce131" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">2.9.2</text:span><text:span text:style-name="T15">¹²</text:span></text:p>
+     <table:table-cell table:style-name="ce131" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">2.9.2</text:span><text:span text:style-name="T12">¹²</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce124" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
@@ -2553,7 +2496,7 @@
      <table:table-cell table:style-name="ce100" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce149" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T46">2.9.2</text:span><text:span text:style-name="T47">¹²</text:span><text:span text:style-name="T48"> (wheel includes OpenSSL)</text:span></text:p>
+     <table:table-cell table:style-name="ce149" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T36">2.9.2</text:span><text:span text:style-name="T37">¹²</text:span><text:span text:style-name="T38"> (wheel includes OpenSSL)</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce100" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
@@ -2576,7 +2519,7 @@
      <table:table-cell table:number-columns-repeated="2" table:style-name="ce66" office:value-type="string" calcext:value-type="string">
       <text:p>n/a</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce187" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">3.2.1</text:span><text:span text:style-name="T15">¹²</text:span></text:p>
+     <table:table-cell table:style-name="ce187" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T11">3.2.1</text:span><text:span text:style-name="T12">¹²</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce100" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
@@ -2587,9 +2530,10 @@
      <table:table-cell table:style-name="ce124" office:value-type="string" calcext:value-type="string">
       <text:p>3.3.2</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T66">2.9.2</text:span><text:span text:style-name="T67">¹² </text:span><text:span text:style-name="T57">(wheel includes OpenSSL)</text:span></text:p>
+     <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T51">2.9.2</text:span><text:span text:style-name="T52">¹² </text:span><text:span text:style-name="T45">(wheel includes OpenSSL)</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce189" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T72">3.3.2</text:span><text:span text:style-name="T73"> (wheel includes OpenSSL)</text:span></text:p>
+     <table:table-cell table:style-name="ce189" office:value-type="string" calcext:value-type="string">
+      <text:p>3.3.2</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="33"/>
     </table:table-row>
@@ -3097,7 +3041,7 @@
      <table:table-cell table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>21.0.0</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce152" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T38">0.13.1</text:span><text:span text:style-name="T39">⁷</text:span></text:p>
+     <table:table-cell table:style-name="ce152" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T32">0.13.1</text:span><text:span text:style-name="T33">⁷</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce61" office:value-type="string" calcext:value-type="string">
       <text:p>21.0.0</text:p>
@@ -3120,11 +3064,11 @@
      <table:table-cell table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>21.0.0</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce164" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T52">0.13.1</text:span><text:span text:style-name="T39">⁷</text:span></text:p>
+     <table:table-cell table:style-name="ce164" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T41">0.13.1</text:span><text:span text:style-name="T33">⁷</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce167" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T52">0.13.1</text:span><text:span text:style-name="T57">⁷</text:span></text:p>
+     <table:table-cell table:style-name="ce167" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T41">0.13.1</text:span><text:span text:style-name="T45">⁷</text:span></text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce170" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T58">0.13.1</text:span><text:span text:style-name="T59">⁷</text:span></text:p>
+     <table:table-cell table:style-name="ce170" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T46">0.13.1</text:span><text:span text:style-name="T47">⁷</text:span></text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce76" office:value-type="string" calcext:value-type="string">
       <text:p>19.1.0</text:p>
@@ -3555,7 +3499,7 @@
       <text:p>Notes:</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string">
-      <text:p>0. Dependencies above are listed as per the current build process, not for the latest released versions.</text:p>
+      <text:p>0. Dependencies above are listed as per the current build process, not necessarily for the latest released versions of python-package.</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="47"/>
@@ -3578,7 +3522,7 @@
      <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string">
       <text:p>Colour codes:</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T16">DARKGREY</text:span>: Tier 2 platforms and their problematic dependencies</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">DARKGREY</text:span>: Tier 2 platforms and their problematic dependencies</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3591,7 +3535,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">LIGHT GREY</text:span>: Tier 3 platforms and their problematic dependencies</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T14">LIGHT GREY</text:span>: Tier 3 platforms and their problematic dependencies</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3604,7 +3548,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T13">GREEN</text:span>: no known vulnerabilities for Tier 1 platforms</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T8">GREEN</text:span>: no known vulnerabilities for Tier 1 platforms</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3617,7 +3561,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T18">BLUE</text:span>: possible vulnerabilities found upstream, but no released version has them yet</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T15">BLUE</text:span>: possible vulnerabilities found upstream, but no released version has them yet</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3630,7 +3574,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T19">ORANGE</text:span>: minor vulnerabilities found</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T16">ORANGE</text:span>: minor vulnerabilities found</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3643,7 +3587,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T20">RED</text:span>: major vulnerabilities found</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T17">RED</text:span>: major vulnerabilities found</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="9"/>
@@ -3656,12 +3600,12 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T21">MAGENTA</text:span>: vulnerability status could not be established</text:p>
+     <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T18">MAGENTA</text:span>: vulnerability status could not be established</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="10"/>
      <table:table-cell table:style-name="ce66" office:value-type="string" calcext:value-type="string">
-      <text:p>8. n/a</text:p>
+      <text:p>8. https://cve.report/CVE-2018-25032</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce49"/>
      <table:table-cell table:number-columns-repeated="47"/>
@@ -3673,19 +3617,19 @@
      </table:table-cell>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="10"/>
-     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T49">9. </text:span><text:span text:style-name="T49"><text:a xlink:href="https://www.openssl.org/news/openssl-1.0.2-notes.html" xlink:type="simple">https://www.openssl.org/news/openssl-1.0.2-notes.html</text:a></text:span></text:p>
+     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T39">9. </text:span><text:span text:style-name="T39"><text:a xlink:href="https://www.openssl.org/news/openssl-1.0.2-notes.html" xlink:type="simple">https://www.openssl.org/news/openssl-1.0.2-notes.html</text:a></text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="48"/>
     </table:table-row>
     <table:table-row table:style-name="ro4">
      <table:table-cell table:number-columns-repeated="13"/>
-     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T49">10. </text:span><text:span text:style-name="T49"><text:a xlink:href="https://www.openssl.org/news/openssl-1.1.1-notes.html" xlink:type="simple">https://www.openssl.org/news/openssl-1.1.1-notes.html</text:a></text:span></text:p>
+     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T39">10. </text:span><text:span text:style-name="T39"><text:a xlink:href="https://www.openssl.org/news/openssl-1.1.1-notes.html" xlink:type="simple">https://www.openssl.org/news/openssl-1.1.1-notes.html</text:a></text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="48"/>
     </table:table-row>
     <table:table-row table:style-name="ro4">
      <table:table-cell table:number-columns-repeated="13"/>
-     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T49">11. </text:span><text:span text:style-name="T49"><text:a xlink:href="https://github.com/ActiveState/cpython/tags" xlink:type="simple">https://github.com/ActiveState/cpython/tags</text:a></text:span></text:p>
+     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T39">11. </text:span><text:span text:style-name="T39"><text:a xlink:href="https://github.com/ActiveState/cpython/tags" xlink:type="simple">https://github.com/ActiveState/cpython/tags</text:a></text:span></text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="48"/>
     </table:table-row>
@@ -3702,11 +3646,20 @@
      <table:table-cell table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="10"/>
-     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p>13. On Windows, the upstream Python 2.7.18 packages are hot patched with all the ActivePython fixes <text:span text:style-name="T50">except</text:span> CVE-2021-3177</text:p>
+     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string"><text:p>13. On Windows, the upstream Python 2.7.18 packages are hot patched with all the ActivePython fixes <text:span text:style-name="T40">except</text:span> CVE-2021-3177</text:p>
      </table:table-cell>
      <table:table-cell table:number-columns-repeated="48"/>
     </table:table-row>
-    <table:table-row table:style-name="ro1" table:number-rows-repeated="4">
+    <table:table-row table:style-name="ro1">
+     <table:table-cell table:number-columns-repeated="2"/>
+     <table:table-cell table:style-name="ce66"/>
+     <table:table-cell table:number-columns-repeated="10"/>
+     <table:table-cell table:style-name="ce49" office:value-type="string" calcext:value-type="string">
+      <text:p>14. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3572</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="48"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro1" table:number-rows-repeated="3">
      <table:table-cell table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="ce66"/>
      <table:table-cell table:number-columns-repeated="59"/>

--- a/functions.sh
+++ b/functions.sh
@@ -10,9 +10,7 @@ OS=""
 INSTALL_FOLDER=""
 
 # Check if debugging environment variable is set and initialize with 0 if not.
-if [ -z "${DEBUG:-}" ] ; then
-    DEBUG=0
-fi
+DEBUG=${DEBUG-0}
 
 
 help_text_help=\

--- a/pavement.py
+++ b/pavement.py
@@ -36,7 +36,7 @@ SETUP['folders']['source'] = u'src'
 SETUP['repository']['name'] = u'python-package'
 SETUP['test']['package'] = None
 
-SETUP['pypi']['index_url'] = 'https://bin.chevah.com:20443/pypi/simple'
+SETUP['pypi']['index_url'] = os.environ['PIP_INDEX_URL']
 
 SETUP['repository']['name'] = u'python-package'
 SETUP['repository']['github'] = 'https://github.com/chevah/python-package'

--- a/pavement.py
+++ b/pavement.py
@@ -40,16 +40,10 @@ SETUP['pypi']['index_url'] = 'https://bin.chevah.com:20443/pypi/simple'
 
 SETUP['repository']['name'] = u'python-package'
 SETUP['repository']['github'] = 'https://github.com/chevah/python-package'
-SETUP['buildbot']['builders_filter'] = u'python-package'
-SETUP['buildbot']['server'] = 'buildbot.chevah.com'
-SETUP['buildbot']['web_url'] = 'https://buildbot.chevah.com:10433'
 
 RUN_PACKAGES = [
     'zope.interface==3.8.0',
     'twisted==15.5.0.chevah7',
-
-    # Buildbot is used for try scheduler
-    'buildbot==0.8.11.chevah11',
 
     # Required for some unicode handling.
     'unidecode',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -427,7 +427,7 @@ def main():
         sys.stderr.write('"zlib" missing.\n')
         exit_code = 1
     else:
-        print 'zlib %s' % (zlib.__version__,)
+        print 'zlib %s' % (zlib.ZLIB_VERSION,)
 
     try:
         from ssl import OPENSSL_VERSION

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -84,7 +84,7 @@ def get_allowed_deps():
                 '/lib/x86_64-linux-gnu/libutil.so.1',
                 '/lib/x86_64-linux-gnu/libz.so.1',
                 ]
-            elif ubuntu_version == "1804":
+            if ubuntu_version == "1804":
                 allowed_deps.extend([
                     '/lib/x86_64-linux-gnu/libtinfo.so.5',
                     '/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -63,6 +63,7 @@ def get_allowed_deps():
                 '/lib64/libutil.so.1',
                 '/lib64/libz.so.1',
                 ]
+            rhel_version = CHEVAH_OS[4:]
             if rhel_version.startswith("8"):
                 allowed_deps.extend([
                     '/lib64/libcrypto.so.1.1',

--- a/python-modules/chevah-python-test/test_python_binary_dist.py
+++ b/python-modules/chevah-python-test/test_python_binary_dist.py
@@ -63,16 +63,6 @@ def get_allowed_deps():
                 '/lib64/libutil.so.1',
                 '/lib64/libz.so.1',
                 ]
-            rhel_version = CHEVAH_OS[4:]
-            if rhel_version.startswith("7"):
-                allowed_deps.extend([
-                    '/lib64/libcrypto.so.10',
-                    '/lib64/libffi.so.6',
-                    '/lib64/libncursesw.so.5',
-                    '/lib64/libpcre.so.1',
-                    '/lib64/libssl.so.10',
-                    '/lib64/libtinfo.so.5',
-                    ])
             if rhel_version.startswith("8"):
                 allowed_deps.extend([
                     '/lib64/libcrypto.so.1.1',
@@ -81,31 +71,6 @@ def get_allowed_deps():
                     '/lib64/libssl.so.1.1',
                     '/lib64/libtinfo.so.6',
                     ])
-        elif 'amzn' in CHEVAH_OS:
-            # Deps for Amazon Linux 2 (x86_64 only).
-            allowed_deps=[
-                '/lib64/libcom_err.so.2',
-                '/lib64/libcrypto.so.10',
-                '/lib64/libcrypt.so.1',
-                '/lib64/libc.so.6',
-                '/lib64/libdl.so.2',
-                '/lib64/libffi.so.6',
-                '/lib64/libgssapi_krb5.so.2',
-                '/lib64/libk5crypto.so.3',
-                '/lib64/libkeyutils.so.1',
-                '/lib64/libkrb5.so.3',
-                '/lib64/libkrb5support.so.0',
-                '/lib64/libm.so.6',
-                '/lib64/libncursesw.so.6',
-                '/lib64/libpcre.so.1',
-                '/lib64/libpthread.so.0',
-                '/lib64/libresolv.so.2',
-                '/lib64/libselinux.so.1',
-                '/lib64/libssl.so.10',
-                '/lib64/libtinfo.so.6',
-                '/lib64/libutil.so.1',
-                '/lib64/libz.so.1',
-                ]
         elif 'ubuntu' in CHEVAH_OS:
             ubuntu_version = CHEVAH_OS[6:]
             # Common deps for supported Ubuntu LTS with full paths (x86_64).
@@ -119,13 +84,6 @@ def get_allowed_deps():
                 '/lib/x86_64-linux-gnu/libutil.so.1',
                 '/lib/x86_64-linux-gnu/libz.so.1',
                 ]
-            if ubuntu_version == "1604":
-                allowed_deps.extend([
-                    '/lib/x86_64-linux-gnu/libcrypto.so.1.0.0',
-                    '/lib/x86_64-linux-gnu/libssl.so.1.0.0',
-                    '/lib/x86_64-linux-gnu/libtinfo.so.5',
-                    '/usr/lib/x86_64-linux-gnu/libffi.so.6',
-                ])
             elif ubuntu_version == "1804":
                 allowed_deps.extend([
                     '/lib/x86_64-linux-gnu/libtinfo.so.5',
@@ -141,23 +99,6 @@ def get_allowed_deps():
                     '/lib/x86_64-linux-gnu/libtinfo.so.6',
                     '/lib/x86_64-linux-gnu/libffi.so.7',
                 ])
-            if 'arm64' in CHEVAH_ARCH:
-                # Deps with full paths for Ubuntu 16.04 on a Pine64 board.
-                allowed_deps=[
-                    '/lib/aarch64-linux-gnu/libc.so.6',
-                    '/lib/aarch64-linux-gnu/libcrypt.so.1',
-                    '/lib/aarch64-linux-gnu/libcrypto.so.1.0.0',
-                    '/lib/aarch64-linux-gnu/libdl.so.2',
-                    '/lib/aarch64-linux-gnu/libgcc_s.so.1',
-                    '/lib/aarch64-linux-gnu/libm.so.6',
-                    '/lib/aarch64-linux-gnu/libnsl.so.1',
-                    '/lib/aarch64-linux-gnu/libpthread.so.0',
-                    '/lib/aarch64-linux-gnu/libssl.so.1.0.0',
-                    '/lib/aarch64-linux-gnu/libtinfo.so.5',
-                    '/lib/aarch64-linux-gnu/libutil.so.1',
-                    '/lib/aarch64-linux-gnu/libz.so.1',
-                    '/usr/lib/aarch64-linux-gnu/libffi.so.6',
-                    ]
         elif 'alpine' in CHEVAH_OS:
             # Full deps with paths, but no minor versions, for Alpine 3.6+.
             alpine_version = CHEVAH_OS[6:]

--- a/src/openssl/chevahbs
+++ b/src/openssl/chevahbs
@@ -79,12 +79,13 @@ chevahbs_install() {
             echo "Libs/headers installed through the build BAT file."
             ;;
         lnx|aix*)
-            # On CentOS 5, `basename` would also complain of a "missing operand".
+            # On CentOS 5, `basename` would also complain of a missing operand.
             echo "Installing manually to avoid messing with a lib64/ sub-dir:"
             execute cp libcrypto.a libssl.a "$INSTALL_FOLDER"/lib/
-            execute cp -r include/openssl/ "$INSTALL_FOLDER"/include/
-            execute mkdir "$INSTALL_FOLDER"/pkgconfig/
-            execute cp *.pc "$INSTALL_FOLDER"/pkgconfig/
+            # No `cp -r`, as symlinks are copied as-is on AIX with the GNU cp.
+            execute mkdir "$INSTALL_FOLDER"/include/openssl
+            execute cp include/openssl/* "$INSTALL_FOLDER"/include/openssl/
+            execute cp *.pc "$INSTALL_FOLDER"/lib/pkgconfig/
             ;;
         *)
             install_folder=$1


### PR DESCRIPTION
Scope
=====

Build an Ubuntu 22.04 package.


Changes
=======

The latest cryptography version to support Python 2.7 is 3.3.2, and that has no support for OpenSSL 3.0.x.

Therefore, use the generic Linux package on Ubuntu 22.04 for now.

For the record, `cryptography` **3.4.x** has been patched to support that for Python 3 though, e.g. https://814773.bugs.gentoo.org/attachment.cgi?id=743943.


**Drive-by fixes**:
  * Backported minor improvement from `pythia` repo: pypi args, pkg mgmt, openssl manual installation, more error checks.
  * Updated documented external dependencies.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please review changes.

Run the automated tests.

